### PR TITLE
load_template now accepts **args as it feels more natural

### DIFF
--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -126,6 +126,12 @@ class TestConfigNetworkDriver:
 
         self.assertTrue(result)
 
+    def test_load_template(self):
+        """Test load_template method."""
+        self.device.load_template('set_hostname', hostname='my-hostname')
+        diff = self.device.compare_config()
+        self.device.discard_config()
+        self.assertTrue(diff is not '')
 
 class TestGettersNetworkDriver:
 


### PR DESCRIPTION
@mirceaulinic can you review this? What do you think?

The idea is to be able to treat this method in a more natural way, passing what I want in the template as named arguments:

```
driver.load_template('set_ntp_peers', peers=['1.1.1.1', '2.2.2.2'])
```

Alternatively, I wouldn't mind passing a dict, something like:

```
driver.load_template('set_ntp_peers', {'peers': ['1.1.1.1', '2.2.2.2']})
```

So in the template you can do:

```
    {% for peer in peers %}
      peer {{peer}}
    {% endfor %}
```

Instead of:

```
    {% for peer in template_vars %}
      peer {{peer}}
    {% endfor %}
```

Thoughts?