### PR TITLE
replaces static loader with dynamic loader

### DIFF
--- a/napalm_base/__init__.py
+++ b/napalm_base/__init__.py
@@ -14,33 +14,145 @@
 
 """napalm_base package."""
 
-
-def _get_eos_driver():
-    from napalm_eos.eos import EOSDriver
-    return EOSDriver
+import sys
+import imp
 
 
-def _get_junos_driver():
-    from napalm_junos.junos import JunOSDriver
-    return JunOSDriver
+def import_module(name):
+    """Imports a module into the current runtime environment
+
+    This function will take a full path module name and break it into
+    its parts iteratively attempting to import each one.  The function
+    will check to be sure that the module hasn't been previously imported.
+
+    .. doctest::
+
+        >>> import_module('os') #doctest: +ELLIPSIS
+        <module 'os' from '...'>
+
+    :param str name:
+        The name of the module to import
+
+    :returns:
+        The imported Python module
+    """
+    parts = name.split('.')
+    path = None
+    module_name = ''
+    fhandle = None
+
+    for index, part in enumerate(parts):
+        module_name = part if index == 0 else '%s.%s' % (module_name, part)
+        path = [path] if path is not None else path
+
+        try:
+            fhandle, path, descr = imp.find_module(part, path)
+            if module_name in sys.modules:
+                # since imp.load_module works like reload, need to be sure not
+                # to reload a previously loaded module
+                mod = sys.modules[module_name]
+            else:
+                mod = imp.load_module(module_name, fhandle, path, descr)
+        finally:
+            # lets be sure to clean up after ourselves
+            if fhandle:
+                fhandle.close()
+
+    return mod
 
 
-def get_network_driver(vendor):
-    """Given a vendor name returns the network driver."""
-    driver_mapping = {
-        'EOS': _get_eos_driver,
-        'ARISTA': _get_eos_driver,
-        'JUNOS': _get_junos_driver,
-        'JUNIPER': _get_junos_driver,
-        # 'IOS-XR': IOSXRDriver,
-        # 'IOSXR': IOSXRDriver,
-        # 'FORTIOS': FortiOSDriver,
-        # 'NXOS': NXOSDriver,
-        # 'IBM': IBMDriver,
-        # 'IOS' : IOSDriver,
-        # 'PLURIBUS': PluribusDriver
-    }
+def load_module(name):
+    """Attempts to load a module into the current environment
+
+    This function will load a module from the Python sys.path.  It will
+    check to be sure the module wasn't already loaded.  If the module
+    was prevsiouly loaded, it will simply return the loaded module and not
+    reload it
+
+    .. doctest::
+
+        >>> load_module('sys')
+        <module 'sys' (built-in)>
+
+    :param str name:
+        The name of the module to load
+
+    :returns:
+        The named Python module
+
+    :raises ImportError:
+        If the module could not be loaded
+    """
     try:
-        return driver_mapping[vendor.upper()]()
+        mod = None
+        mod = sys.modules[name]
     except KeyError:
-        raise Exception('Vendor/OS not supported: %s' % vendor)
+        try:
+            mod = import_module(name)
+        except ImportError:
+            raise
+    finally:
+        if not mod:
+            raise
+        return mod
+
+
+def napalm_namespace(module):
+    """ Prepends the default namespace onto the module name
+
+    The function is only applicable in cases where a module
+    name is provided without a full path namespace.  In this
+    case, the module name is prepended with the device namespace.
+    If the module name is a fully qualified namespace, the
+    module name is returned.
+
+    .. doctest::
+
+        >>> napalm_namespace('test')
+        'napalm_test.test'
+        >>> napalm_namespace('napalm.test')
+        'napalm.test'
+
+    :param str module:
+        The name of the module to verify
+
+    :returns:
+        The fully qualified module namespace
+    """
+    if '.' in module:
+        return module
+    return 'napalm_{}.{}'.format(module, module)
+
+
+def get_network_driver(module, loader='load_driver', *args, **kwargs):
+    """Attempts to load a class instance from the module
+
+    The function will load the specified module and create
+    an instance.  The loader works by looking for a function in
+    the module and loading it.
+
+    :param str module:
+        The name of the module to dynamically load
+
+    :param str loader:
+        The name of the function to call to load the driver.  The
+        default value is 'load_driver'
+
+    :param args:
+        An ordered set of arbitrary arguments that are passed to the
+        instance function
+
+    :param kwargs:
+        An unordered set of arbitrary keyword arguments that are passed
+        to the instance function
+
+    :returns object:
+        Instantiates a Python object an returns it
+    """
+    loader = loader or 'load_driver'
+    mod = load_module(napalm_namespace(module))
+    if not hasattr(mod, loader):
+        raise Exception('Missing {} function'.format(loader))
+    func = getattr(mod, loader)
+    return func(*args, **kwargs)
+


### PR DESCRIPTION
This commit replaces the static loading of drivers with a dynamic loader.  The
dynamic loader can load modules using either a full path namespace
or a single module name.  If the provided name is not a full path
namespace, then the module name is prepended with the default namespace.

For example, calling get_network_driver('foo') will be translated to
'napalm_foo.foo' but get_network_driver('napalm.foo') will not be
modified.