### PR TITLE
Moved load_template() and textfsm_extractor() in helpers module

### DIFF
--- a/napalm_base/__init__.py
+++ b/napalm_base/__init__.py
@@ -83,7 +83,6 @@ def load_module(name):
     :raises ImportError:
         If the module could not be loaded
     """
-
     try:
         mod = None
         mod = sys.modules[name]

--- a/napalm_base/__init__.py
+++ b/napalm_base/__init__.py
@@ -83,6 +83,7 @@ def load_module(name):
     :raises ImportError:
         If the module could not be loaded
     """
+
     try:
         mod = None
         mod = sys.modules[name]
@@ -155,4 +156,3 @@ def get_network_driver(module, loader='load_driver', *args, **kwargs):
         raise Exception('Missing {} function'.format(loader))
     func = getattr(mod, loader)
     return func(*args, **kwargs)
-

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -17,6 +17,7 @@ import sys
 
 # local modules
 import napalm_base.exceptions
+import napalm_base.helpers
 
 
 class NetworkDriver(object):
@@ -79,6 +80,20 @@ class NetworkDriver(object):
         Closes the connection to the device.
         """
         raise NotImplementedError
+
+    def load_template(self, template_name, **template_vars):
+        """
+        Will load a templated configuration on the device.
+
+        :param cls: instance of the driver class
+        :param template_name: identifies the template name
+        :param template_vars: dictionary with the
+
+        :raise DriverTemplateNotImplemented if no template defined for the device type
+        :raise TemplateNotImplemented if the template specified in template_name is not defined
+        :raise TemplateRenderException if the user passed wrong arguments to the template
+        """
+        return napalm_base.helpers.load_template(self, template_name, **template_vars)
 
     def load_replace_candidate(self, filename=None, config=None):
         """

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -34,7 +34,7 @@ class NetworkDriver(object):
         :param optional_args: (dict) Pass additional arguments to underlying driver
         :return:
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def __enter__(self):
         try:
@@ -72,13 +72,13 @@ class NetworkDriver(object):
         """
         Opens a connection to the device.
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def close(self):
         """
         Closes the connection to the device.
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def load_replace_candidate(self, filename=None, config=None):
         """
@@ -92,7 +92,7 @@ class NetworkDriver(object):
         :param config: String containing the desired configuration.
         :raise ReplaceConfigException: If there is an error on the configuration sent.
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def load_merge_candidate(self, filename=None, config=None):
         """
@@ -106,32 +106,32 @@ class NetworkDriver(object):
         :param config: String containing the desired configuration.
         :raise MergeConfigException: If there is an error on the configuration sent.
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def compare_config(self):
         """
         :return: A string showing the difference between the running configuration and the candidate configuration. The\
         running_config is loaded automatically just before doing the comparison so there is no need for you to do it.
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def commit_config(self):
         """
         Commits the changes requested by the method load_replace_candidate or load_merge_candidate.
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def discard_config(self):
         """
         Discards the configuration loaded into the candidate.
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def rollback(self):
         """
         If changes were made, revert changes to the original state.
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_facts(self):
         """
@@ -159,7 +159,7 @@ class NetworkDriver(object):
             }
 
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_interfaces(self):
         """
@@ -213,7 +213,7 @@ class NetworkDriver(object):
                 }
             }
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_lldp_neighbors(self):
         """
@@ -259,7 +259,7 @@ class NetworkDriver(object):
                 ]
             }
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_bgp_neighbors(self):
         """
@@ -281,7 +281,7 @@ class NetworkDriver(object):
                 * accepted_prefixes (int)
                 * sent_prefixes (int)
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_environment(self):
         """
@@ -303,7 +303,7 @@ class NetworkDriver(object):
                  * available_ram (int) - Total amount of RAM installed in the device
                  * used_ram (int) - RAM in use in the device
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_interfaces_counters(self):
         """
@@ -370,7 +370,7 @@ class NetworkDriver(object):
                 }
             }
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_lldp_neighbors_detail(self, interface = ''):
         """
@@ -406,7 +406,7 @@ class NetworkDriver(object):
                 ]
             }
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_bgp_config(self, group = '', neighbor = ''):
         """
@@ -494,7 +494,7 @@ class NetworkDriver(object):
                 }
             }
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def cli(self, *commands):
 
@@ -522,7 +522,7 @@ class NetworkDriver(object):
                                             '''
             }
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_bgp_neighbors_detail(self, neighbor_address = ''):
 
@@ -608,7 +608,7 @@ class NetworkDriver(object):
                 ]
             }
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_arp_table(self):
 
@@ -637,7 +637,7 @@ class NetworkDriver(object):
             ]
 
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_ntp_peers(self):
 
@@ -672,7 +672,7 @@ class NetworkDriver(object):
                 }
             }
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_interfaces_ip(self):
 
@@ -724,7 +724,7 @@ class NetworkDriver(object):
                 }
             }
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_mac_address_table(self):
 
@@ -774,7 +774,7 @@ class NetworkDriver(object):
             However, please note that not all vendors provide all these informations.
             E.g.: field last_move is not available on JUNOS devices etc.
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_route_to(self, destination = '', protocol = ''):
 
@@ -841,7 +841,7 @@ class NetworkDriver(object):
                 ]
             }
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError
 
     def get_snmp_information(self):
 
@@ -991,4 +991,4 @@ class NetworkDriver(object):
                 }
             }
         """
-        raise napalm_base.exceptions.NotImplementedError
+        raise NotImplementedError

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -12,16 +12,14 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-import os
+# std libs
 import sys
-import jinja2
 
-import textfsm
-
+# local modules
 import napalm_base.exceptions
 
 
-class NetworkDriver:
+class NetworkDriver(object):
 
     def __init__(self, hostname, username, password, timeout, optional_args):
         """
@@ -36,7 +34,7 @@ class NetworkDriver:
         :param optional_args: (dict) Pass additional arguments to underlying driver
         :return:
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def __enter__(self):
         try:
@@ -74,13 +72,13 @@ class NetworkDriver:
         """
         Opens a connection to the device.
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def close(self):
         """
         Closes the connection to the device.
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def load_replace_candidate(self, filename=None, config=None):
         """
@@ -94,7 +92,7 @@ class NetworkDriver:
         :param config: String containing the desired configuration.
         :raise ReplaceConfigException: If there is an error on the configuration sent.
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def load_merge_candidate(self, filename=None, config=None):
         """
@@ -108,117 +106,32 @@ class NetworkDriver:
         :param config: String containing the desired configuration.
         :raise MergeConfigException: If there is an error on the configuration sent.
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def compare_config(self):
         """
         :return: A string showing the difference between the running configuration and the candidate configuration. The\
         running_config is loaded automatically just before doing the comparison so there is no need for you to do it.
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def commit_config(self):
         """
         Commits the changes requested by the method load_replace_candidate or load_merge_candidate.
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def discard_config(self):
         """
         Discards the configuration loaded into the candidate.
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def rollback(self):
         """
         If changes were made, revert changes to the original state.
         """
-        raise NotImplementedError
-
-    def load_template(self, template_name, **template_vars):
-        """
-        Will load a templated configuration on the device.
-
-        :param template_name (str) identifies the template name
-        :param template_vars (obj) represents the object to be used by the Jinja template to create the configuration
-        Can be any object type but must respect the constraints defined in the template file.
-
-        :raise DriverTemplateNotImplemented if no template defined for the device type
-        :raise TemplateNotImplemented if the template specified in template_name is not defined
-        :raise TemplateRenderException if the user passed wrong arguments to the template
-        """
-        try:
-            current_dir = os.path.dirname(os.path.abspath(sys.modules[self.__module__].__file__))
-            template_dir_path = '{current_dir}/templates'.format(current_dir=current_dir)
-
-            if not os.path.isdir(template_dir_path):
-                raise napalm_base.exceptions.DriverTemplateNotImplemented("There's no config template defined.")
-
-            loader = jinja2.FileSystemLoader(template_dir_path)
-            environment = jinja2.Environment(loader=loader)
-            template = environment.get_template('{template_name}.j2'.format(
-                template_name=template_name
-            ))
-            configuration = template.render(**template_vars)
-        except jinja2.exceptions.TemplateNotFound:
-            raise napalm_base.exceptions.TemplateNotImplemented(
-                "Template {template_name}.j2 not defined under {path}".format(
-                    template_name=template_name,
-                    path=template_dir_path
-                )
-            )
-        except jinja2.exceptions.UndefinedError as ue:
-            raise napalm_base.exceptions.TemplateRenderException(
-                "Unable to render the template: {}".format(ue.message)
-            )
-        self.load_merge_candidate(config=configuration)
-
-    def _textfsm_extractor(self, template_name, raw_text):
-        """
-        Will apply a TextFSM template over a raw text and return the matching table.
-
-        Main usage of this method will be to extract data form a non-structured output
-        from a network device and return the values in a table format.
-
-        :param template_name: Specifies the name of the template to be used
-        :param raw_text: Text output as the devices prompts on the CLI
-        """
-        textfsm_data = list()
-
-        driver_name = self.__class__.__name__.replace('Driver', '')
-        current_dir = os.path.dirname(os.path.abspath(sys.modules[self.__module__].__file__))
-        template_path = '{current_dir}/utils/textfsm_templates/{template_name}.tpl'.format(
-            current_dir=current_dir,
-            driver_name=driver_name.lower(),
-            template_name=template_name
-        )
-
-        try:
-            fsm_handler = textfsm.TextFSM(open(template_path))
-        except IOError:
-            raise napalm_base.exceptions.TemplateNotImplemented(
-                "TextFSM template {template_name} not defined!".format(
-                    template_name=template_name
-                )
-            )
-        except textfsm.textfsm.TextFSMTemplateError:
-            raise napalm_base.exceptions.TemplateRenderException(
-                "Wrong format of template {template_name}".format(
-                    template_name=template_name
-                )
-            )
-
-        objects = fsm_handler.ParseText(raw_text)
-
-        for obj in objects:
-            index = 0
-            entry = {}
-            for entry_value in obj:
-                entry[fsm_handler.header[index].lower()] = str(entry_value)
-                index += 1
-            textfsm_data.append(entry)
-
-        return textfsm_data
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_facts(self):
         """
@@ -246,7 +159,7 @@ class NetworkDriver:
             }
 
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_interfaces(self):
         """
@@ -300,7 +213,7 @@ class NetworkDriver:
                 }
             }
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_lldp_neighbors(self):
         """
@@ -346,7 +259,7 @@ class NetworkDriver:
                 ]
             }
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_bgp_neighbors(self):
         """
@@ -368,7 +281,7 @@ class NetworkDriver:
                 * accepted_prefixes (int)
                 * sent_prefixes (int)
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_environment(self):
         """
@@ -390,7 +303,7 @@ class NetworkDriver:
                  * available_ram (int) - Total amount of RAM installed in the device
                  * used_ram (int) - RAM in use in the device
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_interfaces_counters(self):
         """
@@ -457,7 +370,7 @@ class NetworkDriver:
                 }
             }
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_lldp_neighbors_detail(self, interface = ''):
         """
@@ -493,7 +406,7 @@ class NetworkDriver:
                 ]
             }
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_bgp_config(self, group = '', neighbor = ''):
         """
@@ -581,7 +494,7 @@ class NetworkDriver:
                 }
             }
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def cli(self, *commands):
 
@@ -609,7 +522,7 @@ class NetworkDriver:
                                             '''
             }
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_bgp_neighbors_detail(self, neighbor_address = ''):
 
@@ -695,7 +608,7 @@ class NetworkDriver:
                 ]
             }
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_arp_table(self):
 
@@ -724,7 +637,7 @@ class NetworkDriver:
             ]
 
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_ntp_peers(self):
 
@@ -759,7 +672,7 @@ class NetworkDriver:
                 }
             }
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_interfaces_ip(self):
 
@@ -811,7 +724,7 @@ class NetworkDriver:
                 }
             }
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_mac_address_table(self):
 
@@ -861,7 +774,7 @@ class NetworkDriver:
             However, please note that not all vendors provide all these informations.
             E.g.: field last_move is not available on JUNOS devices etc.
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_route_to(self, destination = '', protocol = ''):
 
@@ -928,7 +841,7 @@ class NetworkDriver:
                 ]
             }
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError
 
     def get_snmp_information(self):
 
@@ -1078,4 +991,4 @@ class NetworkDriver:
                 }
             }
         """
-        raise NotImplementedError
+        raise napalm_base.exceptions.NotImplementedError

--- a/napalm_base/helpers.py
+++ b/napalm_base/helpers.py
@@ -1,0 +1,102 @@
+"""Helper functions for the NAPALM base."""
+
+# std libs
+import os
+import sys
+
+# third party libs
+import jinja2
+import textfsm
+
+# local modules
+import napalm_base.exceptions
+
+
+def load_template(cls, template_name, **template_vars):
+    """
+    Will load a templated configuration on the device.
+
+    :param cls (object) instance of the driver class
+    :param template_name (str) identifies the template name
+    :param template_vars (obj) represents the object to be used by the Jinja template to create the configuration
+    Can be any object type but must respect the constraints defined in the template file.
+
+    :raise DriverTemplateNotImplemented if no template defined for the device type
+    :raise TemplateNotImplemented if the template specified in template_name is not defined
+    :raise TemplateRenderException if the user passed wrong arguments to the template
+    """
+    try:
+        current_dir = os.path.dirname(os.path.abspath(sys.modules[cls.__module__].__file__))
+        template_dir_path = '{current_dir}/templates'.format(current_dir=current_dir)
+
+        if not os.path.isdir(template_dir_path):
+            raise napalm_base.exceptions.DriverTemplateNotImplemented("There's no config template defined.")
+
+        loader = jinja2.FileSystemLoader(template_dir_path)
+        environment = jinja2.Environment(loader=loader)
+        template = environment.get_template('{template_name}.j2'.format(
+            template_name=template_name
+        ))
+        configuration = template.render(**template_vars)
+    except jinja2.exceptions.TemplateNotFound:
+        raise napalm_base.exceptions.TemplateNotImplemented(
+            "Template {template_name}.j2 not defined under {path}".format(
+                template_name=template_name,
+                path=template_dir_path
+            )
+        )
+    except jinja2.exceptions.UndefinedError as ue:
+        raise napalm_base.exceptions.TemplateRenderException(
+            "Unable to render the template: {}".format(ue.message)
+        )
+    cls.load_merge_candidate(config=configuration)
+
+
+def textfsm_extractor(cls, template_name, raw_text):
+    """
+    Applies a TextFSM template over a raw text and return the matching table.
+
+    Main usage of this method will be to extract data form a non-structured output
+    from a network device and return the values in a table format.
+
+    :param cls: Instance of the driver class
+    :param template_name: Specifies the name of the template to be used
+    :param raw_text: Text output as the devices prompts on the CLI
+    :return: table-like list of entries
+    """
+    textfsm_data = list()
+
+    driver_name = cls.__class__.__name__.replace('Driver', '')
+    current_dir = os.path.dirname(os.path.abspath(sys.modules[cls.__module__].__file__))
+    template_path = '{current_dir}/utils/textfsm_templates/{template_name}.tpl'.format(
+        current_dir=current_dir,
+        driver_name=driver_name.lower(),
+        template_name=template_name
+    )
+
+    try:
+        fsm_handler = textfsm.TextFSM(open(template_path))
+    except IOError:
+        raise napalm_base.exceptions.TemplateNotImplemented(
+            "TextFSM template {template_name} not defined!".format(
+                template_name=template_name
+            )
+        )
+    except textfsm.textfsm.TextFSMTemplateError:
+        raise napalm_base.exceptions.TemplateRenderException(
+            "Wrong format of template {template_name}".format(
+                template_name=template_name
+            )
+        )
+
+    objects = fsm_handler.ParseText(raw_text)
+
+    for obj in objects:
+        index = 0
+        entry = {}
+        for entry_value in obj:
+            entry[fsm_handler.header[index].lower()] = str(entry_value)
+            index += 1
+        textfsm_data.append(entry)
+
+    return textfsm_data

--- a/napalm_base/helpers.py
+++ b/napalm_base/helpers.py
@@ -13,17 +13,6 @@ import napalm_base.exceptions
 
 
 def load_template(cls, template_name, **template_vars):
-    """
-    Will load a templated configuration on the device.
-
-    :param cls: instance of the driver class
-    :param template_name: identifies the template name
-    :param template_vars: dictionary with the
-
-    :raise DriverTemplateNotImplemented if no template defined for the device type
-    :raise TemplateNotImplemented if the template specified in template_name is not defined
-    :raise TemplateRenderException if the user passed wrong arguments to the template
-    """
     try:
         current_dir = os.path.dirname(os.path.abspath(sys.modules[cls.__module__].__file__))
         template_dir_path = '{current_dir}/templates'.format(current_dir=current_dir)

--- a/napalm_base/helpers.py
+++ b/napalm_base/helpers.py
@@ -16,10 +16,9 @@ def load_template(cls, template_name, **template_vars):
     """
     Will load a templated configuration on the device.
 
-    :param cls (object) instance of the driver class
-    :param template_name (str) identifies the template name
-    :param template_vars (obj) represents the object to be used by the Jinja template to create the configuration
-    Can be any object type but must respect the constraints defined in the template file.
+    :param cls: instance of the driver class
+    :param template_name: identifies the template name
+    :param template_vars: dictionary with the
 
     :raise DriverTemplateNotImplemented if no template defined for the device type
     :raise TemplateNotImplemented if the template specified in template_name is not defined


### PR DESCRIPTION
Also need to move the templates in all napalm_*:
Noticed they still reside under /templates/[DRIVER_NAME]/ instead of /templates/