### PR TITLE
Define get_probes_config() and get_probes_results()

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -946,16 +946,132 @@ class NetworkDriver:
             * acl (string) # acl number or name
             * mode (string) # read-write (rw), read-only (ro)
 
-        Example Output:
+        Example Output::
 
-        {   'chassis_id': u'Asset Tag 54670',
-        'community': {   u'private': {   'acl': u'12', 'mode': u'rw'},
-                         u'public': {   'acl': u'11', 'mode': u'ro'},
-                         u'public_named_acl': {   'acl': u'ALLOW-SNMP-ACL',
-                                                  'mode': u'ro'},
-                         u'public_no_acl': {   'acl': u'N/A', 'mode': u'ro'}},
-        'contact': u'Joe Smith',
-        'location': u'123 Anytown USA Rack 404'}
-
+            {
+                'chassis_id': u'Asset Tag 54670',
+                'community': {
+                    u'private': {
+                        'acl': u'12',
+                        'mode': u'rw'
+                    },
+                    u'public': {
+                        'acl': u'11',
+                        'mode': u'ro'
+                    },
+                    u'public_named_acl': {
+                        'acl': u'ALLOW-SNMP-ACL',
+                        'mode': u'ro'
+                    },
+                    u'public_no_acl': {
+                        'acl': u'N/A',
+                        'mode': u'ro'
+                    }
+                },
+                'contact' : u'Joe Smith',
+                'location': u'123 Anytown USA Rack 404'
+            }
         """
         raise NotImplementedError
+
+    def get_probes_config(self):
+        """
+        Returns a dictionary with the probes configured on the device.
+        Probes can be either RPM on JunOS devices, either SLA on IOS-XR. Other vendors do not support probes.
+        The keys of the main dictionary represent the name of the probes.
+        Each probe consists on multiple tests, each test name being a key in the probe dictionary.
+        A test has the following keys:
+
+            * probe_type (str)
+            * target (str)
+            * source (str)
+            * probe_count (int)
+            * test_interval (int)
+
+        Example output::
+
+            {
+                'probe1':{
+                    'test1': {
+                        'probe_type'   : 'icmp-ping',
+                        'target'       : '192.168.0.1',
+                        'source'       : '192.168.0.2',
+                        'probe_count'  : 13,
+                        'test_interval': 3
+                    },
+                    'test2': {
+                        'probe_type'   : 'http-ping',
+                        'target'       : '172.17.17.1',
+                        'source'       : '192.17.17.2',
+                        'probe_count'  : 5,
+                        'test_interval': 60
+                    }
+                }
+            }
+        """
+        raise NotImplementedError
+
+    def get_probes_results(self):
+        """
+        Returns a dictionary with the results of the probes.
+        The keys of the main dictionary represent the name of the probes.
+        Each probe consists on multiple tests, each test name being a key in the probe dictionary.
+        A test has the following keys:
+
+            * target (str)
+            * probe_type (str)
+            * probe_count (int)
+            * rtt (float)
+            * round_trip_jitter (float)
+            * current_test_loss (float)
+            * current_test_min_delay (float)
+            * current_test_max_delay (float)
+            * current_test_avg_delay (float)
+            * last_test_min_delay (float)
+            * last_test_max_delay (float)
+            * last_test_avg_delay (float)
+            * global_test_min_delay (float)
+            * global_test_max_delay (float)
+            * global_test_avg_delay (float)
+
+        Example output::
+
+            {
+                'probe1':  {
+                    'test1': {
+                        'last_test_min_delay': 63120.0,
+                        'global_test_min_delay': 62912.0,
+                        'current_test_avg_delay': 63190.0,
+                        'global_test_max_delay': 177349.0,
+                        'current_test_max_delay': 63302.0,
+                        'global_test_avg_delay': 63802.0,
+                        'last_test_avg_delay': 63438.0,
+                        'last_test_max_delay': 65356.0,
+                        'probe_type': 'icmp-ping',
+                        'rtt': 63138.0,
+                        'current_test_loss': 0.0,
+                        'round_trip_jitter': -59.0,
+                        'target': '192.168.0.1',
+                        'probe_count': 15,
+                        'current_test_min_delay': 63138.0
+                    },
+                    'test2': {
+                        'last_test_min_delay': 176384.0,
+                        'global_test_min_delay': 169226.0,
+                        'current_test_avg_delay': 177098.0,
+                        'global_test_max_delay': 292628.0,
+                        'current_test_max_delay': 180055.0,
+                        'global_test_avg_delay': 177959.0,
+                        'last_test_avg_delay': 177178.0,
+                        'last_test_max_delay': 184671.0,
+                        'probe_type': 'icmp-ping',
+                        'rtt': 176449.0,
+                        'current_test_loss': 0.0,
+                        'round_trip_jitter': -34.0,
+                        'target': '172.17.17',
+                        'probe_count': 15,
+                        'current_test_min_delay': 176402.0
+                    }
+                }
+            }
+        """

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1075,3 +1075,4 @@ class NetworkDriver:
                 }
             }
         """
+        raise NotImplementedError

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1019,6 +1019,7 @@ class NetworkDriver:
         A test has the following keys:
 
             * target (str)
+            * source (str)
             * probe_type (str)
             * probe_count (int)
             * rtt (float)
@@ -1039,38 +1040,40 @@ class NetworkDriver:
             {
                 'probe1':  {
                     'test1': {
-                        'last_test_min_delay': 63120.0,
-                        'global_test_min_delay': 62912.0,
-                        'current_test_avg_delay': 63190.0,
-                        'global_test_max_delay': 177349.0,
-                        'current_test_max_delay': 63302.0,
-                        'global_test_avg_delay': 63802.0,
-                        'last_test_avg_delay': 63438.0,
-                        'last_test_max_delay': 65356.0,
-                        'probe_type': 'icmp-ping',
-                        'rtt': 63138.0,
-                        'current_test_loss': 0.0,
-                        'round_trip_jitter': -59.0,
-                        'target': '192.168.0.1',
-                        'probe_count': 15,
-                        'current_test_min_delay': 63138.0
+                        'last_test_min_delay'   : 63.120,
+                        'global_test_min_delay' : 62.912,
+                        'current_test_avg_delay': 63.190,
+                        'global_test_max_delay' : 177.349,
+                        'current_test_max_delay': 63.302,
+                        'global_test_avg_delay' : 63.802,
+                        'last_test_avg_delay'   : 63.438,
+                        'last_test_max_delay'   : 65.356,
+                        'probe_type'            : 'icmp-ping',
+                        'rtt'                   : 63.138,
+                        'current_test_loss'     : 0,
+                        'round_trip_jitter'     : -59.0,
+                        'target'                : '192.168.0.1',
+                        'source'                : '192.168.0.2'
+                        'probe_count'           : 15,
+                        'current_test_min_delay': 63.138
                     },
                     'test2': {
-                        'last_test_min_delay': 176384.0,
-                        'global_test_min_delay': 169226.0,
-                        'current_test_avg_delay': 177098.0,
-                        'global_test_max_delay': 292628.0,
-                        'current_test_max_delay': 180055.0,
-                        'global_test_avg_delay': 177959.0,
-                        'last_test_avg_delay': 177178.0,
-                        'last_test_max_delay': 184671.0,
-                        'probe_type': 'icmp-ping',
-                        'rtt': 176449.0,
-                        'current_test_loss': 0.0,
-                        'round_trip_jitter': -34.0,
-                        'target': '172.17.17',
-                        'probe_count': 15,
-                        'current_test_min_delay': 176402.0
+                        'last_test_min_delay'   : 176.384,
+                        'global_test_min_delay' : 169.226,
+                        'current_test_avg_delay': 177.098,
+                        'global_test_max_delay' : 292.628,
+                        'current_test_max_delay': 180.055,
+                        'global_test_avg_delay' : 177.959,
+                        'last_test_avg_delay'   : 177.178,
+                        'last_test_max_delay'   : 184.671,
+                        'probe_type'            : 'icmp-ping',
+                        'rtt'                   : 176.449,
+                        'current_test_loss'     : 0,
+                        'round_trip_jitter'     : -34.0,
+                        'target'                : '172.17.17.1',
+                        'source'                : '172.17.17.2'
+                        'probe_count'           : 15,
+                        'current_test_min_delay': 176.402
                     }
                 }
             }

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -332,3 +332,25 @@ class TestGettersNetworkDriver:
             result = result and self._test_model(models.snmp_community, community_data)
 
         self.assertTrue(result)
+
+    def test_get_probes_config(self):
+
+        get_probes_config = self.device.get_probes_config()
+        result = len(get_probes_config) > 0
+
+        for probe_name, probe_tests in get_probes_config.iteritems():
+            for test_name, test_config in probe_tests.iteritems():
+                result = result and self._test_model(models.probe_test, test_config)
+
+        self.assertTrue(result)
+
+    def test_get_probes_results(self):
+
+        get_probes_results = self.device.get_probes_results()
+        result = len(get_probes_results) > 0
+
+        for probe_name, probe_tests in get_probes_results.iteritems():
+            for test_name, test_results in probe_tests.iteritems():
+                result = result and self._test_model(models.probe_test_results, test_results)
+
+        self.assertTrue(result)

--- a/napalm_base/test/models.py
+++ b/napalm_base/test/models.py
@@ -215,3 +215,29 @@ snmp_community = {
     'acl'               : unicode,
     'mode'              : unicode,
 }
+
+probe_test = {
+    'probe_type'    : unicode,
+    'target'        : unicode,
+    'source'        : unicode,
+    'probe_count'   : int,
+    'test_interval' : int
+}
+
+probe_test_results = {
+    'target'                : unicode,
+    'probe_type'            : unicode,
+    'probe_count'           : int,
+    'rtt'                   : float,
+    'round_trip_jitter'     : float,
+    'current_test_loss'     : float,
+    'current_test_min_delay': float,
+    'current_test_max_delay': float,
+    'current_test_avg_delay': float,
+    'last_test_min_delay'   : float,
+    'last_test_max_delay'   : float,
+    'last_test_avg_delay'   : float,
+    'global_test_min_delay' : float,
+    'global_test_max_delay' : float,
+    'global_test_avg_delay' : float
+}

--- a/napalm_base/test/models.py
+++ b/napalm_base/test/models.py
@@ -226,11 +226,12 @@ probe_test = {
 
 probe_test_results = {
     'target'                : unicode,
+    'source'                : unicode,
     'probe_type'            : unicode,
     'probe_count'           : int,
     'rtt'                   : float,
     'round_trip_jitter'     : float,
-    'current_test_loss'     : float,
+    'current_test_loss'     : int,
     'current_test_min_delay': float,
     'current_test_max_delay': float,
     'current_test_avg_delay': float,


### PR DESCRIPTION
This refers to RPM probes on JunOS and SLA probes on IOS-XR.
On EOS is might be possible to add custom probes. Will investigate that.