### PR TITLE
NTP stats getter to replace NTP peers getter

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -654,14 +654,15 @@ class NetworkDriver(object):
         """
         raise NotImplementedError
 
-    def get_ntp_peers(self):
+    def get_ntp_stats(self):
 
         """
-        Returns a dictionary of dictionaries with the details of each NTP peer.
+        Returns a dictionary of NTP synchronization statistics.
         Each key of the dictionary is the IP Address of the NTP peer.
         Details of the peer are represented by the following fields:
 
             * referenceid (string)
+            * synchronized (True/False)
             * stratum (int)
             * type (string)
             * when (string)
@@ -676,6 +677,7 @@ class NetworkDriver(object):
             {
                 u'188.114.101.4': {
                     'referenceid'   : u'188.114.100.1',
+                    'synchronized'  : True,
                     'stratum'       : 4,
                     'type'          : u'-',
                     'when'          : u'107',

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -657,10 +657,9 @@ class NetworkDriver(object):
     def get_ntp_stats(self):
 
         """
-        Returns a dictionary of NTP synchronization statistics.
-        Each key of the dictionary is the IP Address of the NTP peer.
-        Details of the peer are represented by the following fields:
+        Returns a list of NTP synchronization statistics.
 
+            * remote (string)
             * referenceid (string)
             * synchronized (True/False)
             * stratum (int)
@@ -674,8 +673,9 @@ class NetworkDriver(object):
 
         For example::
 
-            {
-                u'188.114.101.4': {
+            [
+                {
+                    'remote'        : u'188.114.101.4',
                     'referenceid'   : u'188.114.100.1',
                     'synchronized'  : True,
                     'stratum'       : 4,
@@ -687,7 +687,7 @@ class NetworkDriver(object):
                     'offset'        : -13.866,
                     'jitter'        : 2.695
                 }
-            }
+            ]
         """
         raise NotImplementedError
 

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -276,7 +276,7 @@ class TestGettersNetworkDriver:
         result = len(get_ntp_peers) > 0
 
         for ntp_peer_ip, ntp_peer_details in get_ntp_peers.iteritems():
-            result = result and self._test_model(models.ntp_peer, ntp_peer_details)
+            result = result and self._test_model(models.ntp_stats, ntp_peer_details)
 
         self.assertTrue(result)
 

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -270,12 +270,12 @@ class TestGettersNetworkDriver:
 
         self.assertTrue(result)
 
-    def test_get_ntp_peers(self):
+    def test_get_ntp_stats(self):
 
-        get_ntp_peers = self.device.get_ntp_peers()
-        result = len(get_ntp_peers) > 0
+        get_ntp_stats = self.device.get_ntp_stats()
+        result = len(get_ntp_stats) > 0
 
-        for ntp_peer_ip, ntp_peer_details in get_ntp_peers.iteritems():
+        for ntp_peer_details in get_ntp_stats:
             result = result and self._test_model(models.ntp_stats, ntp_peer_details)
 
         self.assertTrue(result)

--- a/napalm_base/test/models.py
+++ b/napalm_base/test/models.py
@@ -165,6 +165,7 @@ arp_table = {
 }
 
 ntp_stats = {
+    'remote'        : unicode,
     'referenceid'   : unicode,
     'synchronized'  : bool,
     'stratum'       : int,

--- a/napalm_base/test/models.py
+++ b/napalm_base/test/models.py
@@ -164,8 +164,9 @@ arp_table = {
     'age'       : float
 }
 
-ntp_peer = {
+ntp_stats = {
     'referenceid'   : unicode,
+    'synchronized'  : bool,
     'stratum'       : int,
     'type'          : unicode,
     'when'          : unicode,


### PR DESCRIPTION
The actual method get_ntp_peers() returns a dictionary with the statistics of the configured NTP peers. It would feel more natural to be called get_ntp_stats(). For the reasons presented below, we need to implement a different method get_ntp_peers() to retrieve the NTP config.

Unfortunately the current implementation of get_ntp_peers() be used to determine the NTP peers configured on the device (at least on JunOS which returns the raw output of the _ntpq_ Unix daemon), where the columns have a max width of 15 characters:

```
-2400:cb00:22:10 162.158.5.4      5 u  886 1024  377  139.385  -14.783   4.655
```


```2400:cb00:22:10``` obviously is not a valid IPv6 address so, right now, get_ntp_peers() cannot be completely reliable in terms of remote NTP address.

Actions needed:

  - since the addresses might start with the same prefix, might have key conflicts in the main dictionary (on the device can configure NTP peers 2400:cb00:22:10::1 and 2400:cb00:22:10::2 or whatever, the device will display two entries, one for each, but because of column width limit, will shrink the remote details column to 2400:cb00:22:10. Thus, in the current implementation, will appear only one key, the value having the sync stats of the latest entry). Solution: transform the dict into list.

  - implement get_ntp_peers() to get the config from the device and return a list of NTP peers