### PR TITLE
Add get_ntp_peers()

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -654,6 +654,26 @@ class NetworkDriver(object):
         """
         raise NotImplementedError
 
+
+    def get_ntp_peers(self):
+
+        """
+        Returns a list of NTP peers configured on the device.
+
+        Example::
+
+            [
+                '192.168.0.1',
+                '17.72.148.53',
+                '37.187.56.220',
+                '162.158.20.18'
+            ]
+
+        """
+
+        raise NotImplementedError
+
+
     def get_ntp_stats(self):
 
         """

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -658,16 +658,18 @@ class NetworkDriver(object):
     def get_ntp_peers(self):
 
         """
-        Returns a list of NTP peers configured on the device.
+        Returns the NTP peers configuration as dictionary.
+        The keys of the dictionary represent the IP Addresses of the peers.
+        Inner dictionaries do not have yet any available keys.
 
         Example::
 
-            [
-                '192.168.0.1',
-                '17.72.148.53',
-                '37.187.56.220',
-                '162.158.20.18'
-            ]
+            {
+                '192.168.0.1': {},
+                '17.72.148.53': {},
+                '37.187.56.220': {},
+                '162.158.20.18': {}
+            }
 
         """
 

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -273,8 +273,11 @@ class TestGettersNetworkDriver:
     def test_get_ntp_peers(self):
 
         get_ntp_peers = self.device.get_ntp_peers()
-        result = isinstance(get_ntp_peers, list)
-        result = result and len(get_ntp_peers) > 0
+        result = len(get_ntp_peers) > 0
+
+        for peer, peer_details in get_ntp_peers.iteritems():
+            result = result and isinstance(peer, unicode)
+            result = result and self._test_model(models.ntp_peer, peer_details)
 
         self.assertTrue(result)
 

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -270,6 +270,14 @@ class TestGettersNetworkDriver:
 
         self.assertTrue(result)
 
+    def test_get_ntp_peers(self):
+
+        get_ntp_peers = self.device.get_ntp_peers()
+        result = isinstance(get_ntp_peers, list)
+        result = result and len(get_ntp_peers) > 0
+
+        self.assertTrue(result)
+
     def test_get_ntp_stats(self):
 
         get_ntp_stats = self.device.get_ntp_stats()

--- a/napalm_base/test/models.py
+++ b/napalm_base/test/models.py
@@ -164,6 +164,10 @@ arp_table = {
     'age'       : float
 }
 
+ntp_peer = {
+    # will populate it in the future wit potential keys
+}
+
 ntp_stats = {
     'remote'        : unicode,
     'referenceid'   : unicode,


### PR DESCRIPTION
As discussed in https://github.com/napalm-automation/napalm-base/pull/12, will reimplement get_ntp_peers() to return a list of NTP peers as configured on the device.