### PR TITLE
get_probes_results(): last_test_loss replaces current_test_loss

### DIFF
--- a/napalm_base/test/models.py
+++ b/napalm_base/test/models.py
@@ -233,7 +233,7 @@ probe_test_results = {
     'probe_count'           : int,
     'rtt'                   : float,
     'round_trip_jitter'     : float,
-    'current_test_loss'     : int,
+    'last_test_loss'        : int,
     'current_test_min_delay': float,
     'current_test_max_delay': float,
     'current_test_avg_delay': float,


### PR DESCRIPTION
Small change for get_probes_results()
See https://github.com/napalm-automation/napalm-base/pull/9