### PR TITLE
New testing framework

### DIFF
--- a/napalm_base/test/conftest.py
+++ b/napalm_base/test/conftest.py
@@ -1,0 +1,46 @@
+"""Test fixtures."""
+import json
+import os
+import sys
+
+NAPALM_TEST_MOCK = os.getenv('NAPALM_TEST_MOCK', default=True)
+NAPALM_HOSTNAME = os.getenv('NAPALM_HOSTNAME', default='127.0.0.1')
+NAPALM_USERNAME = os.getenv('NAPALM_USERNAME', default='vagrant')
+NAPALM_PASSWORD = os.getenv('NAPALM_PASSWORD', default='vagrant')
+NAPALM_OPTIONAL_ARGS = json.loads(os.getenv('NAPALM_OPTIONAL_ARGS', default='{"port": 12443}'))
+
+
+def set_device_parameters(request):
+    """Set up the class."""
+    request.cls.device = request.cls.driver(NAPALM_HOSTNAME,
+                                            NAPALM_USERNAME,
+                                            NAPALM_PASSWORD,
+                                            timeout=60,
+                                            optional_args=NAPALM_OPTIONAL_ARGS)
+    if os.getenv('NAPALM_TEST_MOCK', default=True):
+        request.cls.device.device = request.cls.fake_driver()
+        module_file = os.path.dirname(sys.modules[request.cls.__module__].__file__)
+        request.cls.device.mocked_data_dir = os.path.join(module_file, 'mocked_data')
+    else:
+        request.cls.device.mocked_data_dir = None
+    request.cls.device.open()
+
+
+def pytest_generate_tests(metafunc, basefile):
+    """Generate test cases dynamically."""
+    path = os.path.join(os.path.dirname(basefile), 'mocked_data', metafunc.function.__name__)
+
+    if os.path.exists(path):
+        sub_folders = os.listdir(path)
+    else:
+        sub_folders = []
+
+    test_cases = []
+    for test_case in sub_folders:
+        if os.path.isdir(os.path.join(path, test_case)):
+            test_cases.append(test_case)
+
+    if not test_cases:
+        print('\n[NAPALM] We failed to find test cases for {}. Please, add test cases in {}'.format(
+                                                                  metafunc.function.__name__, path))
+    metafunc.parametrize("test_case", test_cases)

--- a/napalm_base/test/conftest.py
+++ b/napalm_base/test/conftest.py
@@ -17,7 +17,7 @@ def set_device_parameters(request):
                                             NAPALM_PASSWORD,
                                             timeout=60,
                                             optional_args=NAPALM_OPTIONAL_ARGS)
-    if os.getenv('NAPALM_TEST_MOCK', default=True):
+    if NAPALM_TEST_MOCK:
         request.cls.device.device = request.cls.fake_driver()
         module_file = os.path.dirname(sys.modules[request.cls.__module__].__file__)
         request.cls.device.mocked_data_dir = os.path.join(module_file, 'mocked_data')

--- a/napalm_base/test/double.py
+++ b/napalm_base/test/double.py
@@ -1,0 +1,46 @@
+"""Base class for Test doubles."""
+
+import json
+import re
+import os
+import sys
+
+
+class BaseTestDouble:
+    """Base class for test doubles."""
+
+    def __init__(self, *args, **kwargs):
+        """Initiate object."""
+        self.current_test = ''
+        self.current_test_case = ''
+
+    def find_file(self, filename):
+        """Find the necessary file for the given test case."""
+        # Find base_dir of submodule
+        module_dir = os.path.dirname(sys.modules[self.__module__].__file__)
+
+        full_path = os.path.join(module_dir, 'mocked_data',
+                                 self.current_test, self.current_test_case, filename)
+
+        if os.path.exists(full_path):
+            return full_path
+        else:
+            raise Exception("Couldn't find file with mocked data: {}".format(full_path))
+
+    @staticmethod
+    def sanitize_text(text):
+        """Remove some weird characters from text, useful for building filenames from commands."""
+        regexp = r'[\[\]\*\^\+\s\|\/]'
+        return re.sub(regexp, '_', text)[0:150]
+
+    @staticmethod
+    def read_json_file(filename):
+        """Parse a json file and return its content."""
+        with open(filename) as data_file:
+            return json.load(data_file)
+
+    @staticmethod
+    def read_txt_file(filename):
+        """Return the content of a file."""
+        with open(filename) as data_file:
+            return data_file.read()

--- a/napalm_base/test/double.py
+++ b/napalm_base/test/double.py
@@ -25,7 +25,7 @@ class BaseTestDouble:
         if os.path.exists(full_path):
             return full_path
         else:
-            raise Exception("Couldn't find file with mocked data: {}".format(full_path))
+            raise IOError("Couldn't find file with mocked data: {}".format(full_path))
 
     @staticmethod
     def sanitize_text(text):
@@ -44,3 +44,14 @@ class BaseTestDouble:
         """Return the content of a file."""
         with open(filename) as data_file:
             return data_file.read()
+
+    @property
+    def expected_result(self):
+        """Return the expected result for the current test case."""
+        filename = self.find_file('expected_result.json')
+
+        with open(filename, mode='r') as f:
+            try:
+                return json.loads(f.read())
+            except ValueError:
+                raise ValueError("No JSON object could be decoded on filename: {}".format(filename))

--- a/napalm_base/test/double.py
+++ b/napalm_base/test/double.py
@@ -55,3 +55,20 @@ class BaseTestDouble:
                 return json.loads(f.read())
             except ValueError:
                 raise ValueError("No JSON object could be decoded on filename: {}".format(filename))
+
+
+def _string_key_to_int(param):
+    """For a given dictionary, convert all strings that represent a number into an int."""
+    new_dict = {}
+
+    if isinstance(param, list):
+        return [_string_key_to_int(element) for element in param]
+    elif isinstance(param, dict):
+        for key, value in param.items():
+            try:
+                new_dict[int(key)] = _string_key_to_int(value)
+            except ValueError:
+                new_dict[key] = _string_key_to_int(value)
+        return new_dict
+    else:
+        return param

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -19,14 +19,14 @@ def wrap_test_cases(func):
 
         try:
             result = func(cls)
-            not_implented = False
+            not_implemented = False
         except NotImplementedError:
-            not_implented = True
+            not_implemented = True
 
         cls.device.device.current_test = ''
         cls.device.device.current_test_case = ''
 
-        if not_implented:
+        if not_implemented:
             pytest.skip("Method not implemented")
         else:
             return result

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -2,22 +2,33 @@
 
 from __future__ import print_function
 
-import json
-
-import models
-import pytest
-
 import functools
+import json
+import itertools
+
+from double import BaseTestDouble
 
 import helpers
 
-from double import BaseTestDouble
+import models
+
+
+import pytest
+
+
+def list_dicts_diff(prv, nxt):
+    """Compare two lists of dicts."""
+    result = []
+    for prv_element, nxt_element in itertools.izip_longest(prv, nxt, fillvalue={}):
+        intermediate_result = dict_diff(prv_element, nxt_element)
+        if intermediate_result:
+            result.append(intermediate_result)
+    return result
 
 
 def dict_diff(prv, nxt):
     """Return a dict of keys that differ with another config object."""
     keys = set(prv.keys() + nxt.keys())
-
     result = {}
 
     for k in keys:
@@ -49,12 +60,13 @@ def wrap_test_cases(func):
             not_implemented = False
 
             if isinstance(cls.device.device, BaseTestDouble):
-                diff = dict_diff(result, cls.device.device.expected_result)
-                try:
-                    assert not diff, "Expected result varies on some keys {}".format(diff)
-                except AssertionError:
+                if isinstance(result, list):
+                    diff = list_dicts_diff(result, cls.device.device.expected_result)
+                else:
+                    diff = dict_diff(result, cls.device.device.expected_result)
+                if diff:
                     print("Resulting JSON object was: {}".format(json.dumps(result)))
-                    raise
+                    raise AssertionError("Expected result varies on some keys {}".format(diff))
 
         except NotImplementedError:
             not_implemented = True
@@ -82,41 +94,318 @@ class BaseTestGetters:
 
     @wrap_test_cases
     def test_get_interfaces(self):
-        """Test get_interfaces method."""
+        """Test get_interfaces."""
         get_interfaces = self.device.get_interfaces()
-        assert len(get_interfaces) > 0
+        result = len(get_interfaces) > 0
 
         for interface, interface_data in get_interfaces.iteritems():
-            assert helpers.test_model(models.interface, interface_data)
+            result = result and helpers.test_model(models.interface, interface_data)
 
+        assert result
         return get_interfaces
 
     @wrap_test_cases
+    def test_get_lldp_neighbors(self):
+        """Test get_lldp_neighbors."""
+        get_lldp_neighbors = self.device.get_lldp_neighbors()
+        result = len(get_lldp_neighbors) > 0
+
+        for interface, neighbor_list in get_lldp_neighbors.iteritems():
+            for neighbor in neighbor_list:
+                result = result and helpers.test_model(models.lldp_neighbors, neighbor)
+
+        assert result
+        return get_lldp_neighbors
+
+    @wrap_test_cases
+    def test_get_interfaces_counters(self):
+        """Test get_interfaces_counters."""
+        get_interfaces_counters = self.device.get_interfaces_counters()
+        result = len(self.device.get_interfaces_counters()) > 0
+
+        for interface, interface_data in get_interfaces_counters.iteritems():
+            result = result and helpers.test_model(models.interface_counters, interface_data)
+
+        assert result
+        return get_interfaces_counters
+
+    @wrap_test_cases
+    def test_get_environment(self):
+        """Test get_environment."""
+        environment = self.device.get_environment()
+        result = len(environment) > 0
+
+        for fan, fan_data in environment['fans'].iteritems():
+            result = result and helpers.test_model(models.fan, fan_data)
+
+        for power, power_data in environment['power'].iteritems():
+            result = result and helpers.test_model(models.power, power_data)
+
+        for temperature, temperature_data in environment['temperature'].iteritems():
+            result = result and helpers.test_model(models.temperature, temperature_data)
+
+        for cpu, cpu_data in environment['cpu'].iteritems():
+            result = result and helpers.test_model(models.cpu, cpu_data)
+
+        result = result and helpers.test_model(models.memory, environment['memory'])
+
+        assert result
+        return environment
+
+    @wrap_test_cases
     def test_get_bgp_neighbors(self):
-        """Test get_bgp_neighbors method."""
+        """Test get_bgp_neighbors."""
         get_bgp_neighbors = self.device.get_bgp_neighbors()
-        assert 'global' in get_bgp_neighbors.keys(), "global is not part of the returned vrfs"
+        result = 'global' in get_bgp_neighbors.keys()
 
-        for vrf, vrf_data in get_bgp_neighbors.iteritems():
-            assert isinstance(vrf_data['router_id'], unicode), "router_id is not unicode"
+        if not result:
+            print('global is not part of the returned vrfs')
+        else:
+            for vrf, vrf_data in get_bgp_neighbors.iteritems():
+                result = result and isinstance(vrf_data['router_id'], unicode)
+                if not result:
+                    print('router_id is not unicode')
 
-            for peer, peer_data in vrf_data['peers'].iteritems():
-                assert helpers.test_model(models.peer, peer_data)
+                for peer, peer_data in vrf_data['peers'].iteritems():
+                    result = result and helpers.test_model(models.peer, peer_data)
 
-                for af, af_data in peer_data['address_family'].iteritems():
-                    assert helpers.test_model(models.af, af_data)
+                    for af, af_data in peer_data['address_family'].iteritems():
+                        result = result and helpers.test_model(models.af, af_data)
 
-        return get_bgp_neighbors
+            assert result
+            return get_bgp_neighbors
+
+    @wrap_test_cases
+    def test_get_lldp_neighbors_detail(self):
+        """Test get_lldp_neighbors_detail."""
+        get_lldp_neighbors_detail = self.device.get_lldp_neighbors_detail()
+        result = len(get_lldp_neighbors_detail) > 0
+
+        for interface, neighbor_list in get_lldp_neighbors_detail.iteritems():
+            for neighbor in neighbor_list:
+                result = result and helpers.test_model(models.lldp_neighbors_detail, neighbor)
+
+        assert result
+        return get_lldp_neighbors_detail
+
+    @wrap_test_cases
+    def test_get_bgp_config(self):
+        """Test get_bgp_config."""
+        get_bgp_config = self.device.get_bgp_config()
+        result = len(get_bgp_config) > 0
+
+        for bgp_group in get_bgp_config.values():
+            result = result and helpers.test_model(models.bgp_config_group, bgp_group)
+            for bgp_neighbor in bgp_group.get('neighbors', {}).values():
+                result = result and helpers.test_model(models.bgp_config_neighbor, bgp_neighbor)
+
+        assert result
+        return get_bgp_config
 
     @wrap_test_cases
     def test_get_bgp_neighbors_detail(self):
-        """Test get_bgp_neighbors_detail method."""
+        """Test get_bgp_neighbors_detail."""
         get_bgp_neighbors_detail = self.device.get_bgp_neighbors_detail()
 
-        assert len(get_bgp_neighbors_detail) > 0
+        result = len(get_bgp_neighbors_detail) > 0
 
-        for remote_as, neighbor_list in get_bgp_neighbors_detail.iteritems():
-            for neighbor in neighbor_list:
-                assert helpers.test_model(models.peer_details, neighbor)
+        for vrf, vrf_ases in get_bgp_neighbors_detail.iteritems():
+            result = result and isinstance(vrf, unicode)
+            for remote_as, neighbor_list in vrf_ases.iteritems():
+                result = result and isinstance(remote_as, int)
+                for neighbor in neighbor_list:
+                    result = result and helpers.test_model(models.peer_details, neighbor)
 
+        assert result
         return get_bgp_neighbors_detail
+
+    @wrap_test_cases
+    def test_get_arp_table(self):
+        """Test get_arp_table."""
+        get_arp_table = self.device.get_arp_table()
+        result = len(get_arp_table) > 0
+
+        for arp_entry in get_arp_table:
+            result = result and helpers.test_model(models.arp_table, arp_entry)
+
+        assert result
+        return get_arp_table
+
+    @wrap_test_cases
+    def test_get_ntp_peers(self):
+        """Test get_ntp_peers."""
+        get_ntp_peers = self.device.get_ntp_peers()
+        result = len(get_ntp_peers) > 0
+
+        for peer, peer_details in get_ntp_peers.iteritems():
+            result = result and isinstance(peer, unicode)
+            result = result and helpers.test_model(models.ntp_peer, peer_details)
+
+        assert result
+        return get_ntp_peers
+
+    @wrap_test_cases
+    def test_get_ntp_stats(self):
+        """Test get_ntp_stats."""
+        get_ntp_stats = self.device.get_ntp_stats()
+        result = len(get_ntp_stats) > 0
+
+        for ntp_peer_details in get_ntp_stats:
+            result = result and helpers.test_model(models.ntp_stats, ntp_peer_details)
+
+        assert result
+        return get_ntp_stats
+
+    @wrap_test_cases
+    def test_get_interfaces_ip(self):
+        """Test get_interfaces_ip."""
+        get_interfaces_ip = self.device.get_interfaces_ip()
+        result = len(get_interfaces_ip) > 0
+
+        for interface, interface_details in get_interfaces_ip.iteritems():
+            ipv4 = interface_details.get('ipv4', {})
+            ipv6 = interface_details.get('ipv6', {})
+            for ip, ip_details in ipv4.iteritems():
+                result = result and helpers.test_model(models.interfaces_ip, ip_details)
+            for ip, ip_details in ipv6.iteritems():
+                result = result and helpers.test_model(models.interfaces_ip, ip_details)
+
+        assert result
+        return get_interfaces_ip
+
+    @wrap_test_cases
+    def test_get_mac_address_table(self):
+        """Test get_mac_address_table."""
+        get_mac_address_table = self.device.get_mac_address_table()
+        assert len(get_mac_address_table) > 0
+
+        for mac_table_entry in get_mac_address_table:
+            assert helpers.test_model(models.mac_address_table, mac_table_entry)
+
+        return get_mac_address_table
+
+    @wrap_test_cases
+    def test_get_route_to(self):
+        """Test get_route_to."""
+        destination = '1.0.4.0/24'
+        protocol = 'bgp'
+        get_route_to = self.device.get_route_to(destination=destination, protocol=protocol)
+
+        result = len(get_route_to) > 0
+
+        for prefix, routes in get_route_to.iteritems():
+            for route in routes:
+                result = result and helpers.test_model(models.route, route)
+
+        assert result
+        return get_route_to
+
+    @wrap_test_cases
+    def test_get_snmp_information(self):
+        """Test get_snmp_information."""
+        get_snmp_information = self.device.get_snmp_information()
+
+        result = len(get_snmp_information) > 0
+
+        for snmp_entry in get_snmp_information:
+            result = result and helpers.test_model(models.snmp, get_snmp_information)
+
+        for community, community_data in get_snmp_information['community'].iteritems():
+            result = result and helpers.test_model(models.snmp_community, community_data)
+
+        assert result
+        return get_snmp_information
+
+    @wrap_test_cases
+    def test_get_probes_config(self):
+        """Test get_probes_config."""
+        get_probes_config = self.device.get_probes_config()
+
+        result = len(get_probes_config) > 0
+
+        for probe_name, probe_tests in get_probes_config.iteritems():
+            for test_name, test_config in probe_tests.iteritems():
+                result = result and helpers.test_model(models.probe_test, test_config)
+
+        assert result
+        return get_probes_config
+
+    @wrap_test_cases
+    def test_get_probes_results(self):
+        """Test get_probes_results."""
+        get_probes_results = self.device.get_probes_results()
+        result = len(get_probes_results) > 0
+
+        for probe_name, probe_tests in get_probes_results.iteritems():
+            for test_name, test_results in probe_tests.iteritems():
+                result = result and helpers.test_model(models.probe_test_results, test_results)
+
+        assert result
+        return get_probes_results
+
+    @wrap_test_cases
+    def test_ping(self):
+        """Test ping."""
+        destination = '8.8.8.8'
+        get_ping = self.device.ping(destination)
+        result = isinstance(get_ping.get('success'), dict)
+        ping_results = get_ping.get('success', {})
+
+        result = result and helpers.test_model(models.ping, ping_results)
+
+        for ping_result in ping_results.get('results', []):
+            result = result and helpers.test_model(models.ping_result, ping_result)
+
+        assert result
+        return get_ping
+
+    @wrap_test_cases
+    def test_traceroute(self):
+        """Test traceroute."""
+        destination = '8.8.8.8'
+        get_traceroute = self.device.traceroute(destination)
+        result = isinstance(get_traceroute.get('success'), dict)
+        traceroute_results = get_traceroute.get('success', {})
+
+        for hope_id, hop_result in traceroute_results.iteritems():
+            for probe_id, probe_result in hop_result.get('probes', {}).iteritems():
+                result = result and helpers.test_model(models.traceroute, probe_result)
+
+        assert result
+        return get_traceroute
+
+    @wrap_test_cases
+    def test_get_users(self):
+        """Test get_users."""
+        get_users = self.device.get_users()
+        result = len(get_users)
+
+        for user, user_details in get_users.iteritems():
+            result = result and helpers.test_model(models.users, user_details)
+            result = result and (0 <= user_details.get('level') <= 15)
+
+        assert result
+        return get_users
+
+    @wrap_test_cases
+    def test_get_optics(self):
+        """Test get_optics."""
+        get_optics = self.device.get_optics()
+        assert isinstance(get_optics, dict)
+
+        for iface, iface_data in get_optics.iteritems():
+            assert isinstance(iface, unicode)
+            for channel in iface_data['physical_channels']['channel']:
+                assert len(channel) == 2
+                assert isinstance(channel['index'], int)
+                for field in ['input_power', 'output_power',
+                              'laser_bias_current']:
+
+                    assert len(channel['state'][field]) == 4
+                    assert isinstance(channel['state'][field]['instant'],
+                                      float)
+                    assert isinstance(channel['state'][field]['avg'], float)
+                    assert isinstance(channel['state'][field]['min'], float)
+                    assert isinstance(channel['state'][field]['max'], float)
+
+        return get_optics

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -2,12 +2,39 @@
 
 from __future__ import print_function
 
+import json
+
 import models
 import pytest
 
 import functools
 
 import helpers
+
+from double import BaseTestDouble
+
+
+def dict_diff(prv, nxt):
+    """Return a dict of keys that differ with another config object."""
+    keys = set(prv.keys() + nxt.keys())
+
+    result = {}
+
+    for k in keys:
+        if isinstance(prv.get(k), dict):
+            if isinstance(nxt.get(k), dict):
+                "If both are dicts we do a recursive call."
+                diff = dict_diff(prv.get(k), nxt.get(k))
+                if diff:
+                    result[k] = diff
+            else:
+                "If only one is a dict they are clearly different"
+                result[k] = {'result': prv.get(k), 'expected': nxt.get(k)}
+        else:
+            "Ellipsis is a wildcard."""
+            if prv.get(k) != nxt.get(k) and nxt.get(k) != "...":
+                result[k] = {'result': prv.get(k), 'expected': nxt.get(k)}
+    return result
 
 
 def wrap_test_cases(func):
@@ -20,6 +47,15 @@ def wrap_test_cases(func):
         try:
             result = func(cls)
             not_implemented = False
+
+            if isinstance(cls.device.device, BaseTestDouble):
+                diff = dict_diff(result, cls.device.device.expected_result)
+                try:
+                    assert not diff, "Expected result varies on some keys {}".format(diff)
+                except AssertionError:
+                    print("Resulting JSON object was: {}".format(json.dumps(result)))
+                    raise
+
         except NotImplementedError:
             not_implemented = True
 
@@ -41,51 +77,46 @@ class BaseTestGetters:
     def test_get_facts(self):
         """Test get_facts method."""
         facts = self.device.get_facts()
-        result = helpers.test_model(models.facts, facts)
-        assert result
+        assert helpers.test_model(models.facts, facts)
+        return facts
 
     @wrap_test_cases
     def test_get_interfaces(self):
         """Test get_interfaces method."""
         get_interfaces = self.device.get_interfaces()
-        result = len(get_interfaces) > 0
+        assert len(get_interfaces) > 0
 
         for interface, interface_data in get_interfaces.iteritems():
-            result = result and helpers.test_model(models.interface, interface_data)
+            assert helpers.test_model(models.interface, interface_data)
 
-        assert result
+        return get_interfaces
 
     @wrap_test_cases
     def test_get_bgp_neighbors(self):
         """Test get_bgp_neighbors method."""
         get_bgp_neighbors = self.device.get_bgp_neighbors()
-        result = 'global' in get_bgp_neighbors.keys()
+        assert 'global' in get_bgp_neighbors.keys(), "global is not part of the returned vrfs"
 
-        if not result:
-            print('global is not part of the returned vrfs')
-        else:
-            for vrf, vrf_data in get_bgp_neighbors.iteritems():
-                result = result and isinstance(vrf_data['router_id'], unicode)
-                if not result:
-                    print('router_id is not unicode')
+        for vrf, vrf_data in get_bgp_neighbors.iteritems():
+            assert isinstance(vrf_data['router_id'], unicode), "router_id is not unicode"
 
-                for peer, peer_data in vrf_data['peers'].iteritems():
-                    result = result and helpers.test_model(models.peer, peer_data)
+            for peer, peer_data in vrf_data['peers'].iteritems():
+                assert helpers.test_model(models.peer, peer_data)
 
-                    for af, af_data in peer_data['address_family'].iteritems():
-                        result = result and helpers.test_model(models.af, af_data)
+                for af, af_data in peer_data['address_family'].iteritems():
+                    assert helpers.test_model(models.af, af_data)
 
-            assert result
+        return get_bgp_neighbors
 
     @wrap_test_cases
     def test_get_bgp_neighbors_detail(self):
         """Test get_bgp_neighbors_detail method."""
         get_bgp_neighbors_detail = self.device.get_bgp_neighbors_detail()
 
-        result = len(get_bgp_neighbors_detail) > 0
+        assert len(get_bgp_neighbors_detail) > 0
 
         for remote_as, neighbor_list in get_bgp_neighbors_detail.iteritems():
             for neighbor in neighbor_list:
-                result = result and helpers.test_model(models.peer_details, neighbor)
+                assert helpers.test_model(models.peer_details, neighbor)
 
-        assert result
+        return get_bgp_neighbors_detail

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -1,0 +1,91 @@
+"""Testing framework."""
+
+from __future__ import print_function
+
+import models
+import pytest
+
+import functools
+
+import helpers
+
+
+def wrap_test_cases(func):
+    """Wrap test cases."""
+    @functools.wraps(func)
+    def wrapper(cls, test_case):
+        cls.device.device.current_test = func.__name__
+        cls.device.device.current_test_case = test_case
+
+        try:
+            result = func(cls)
+            not_implented = False
+        except NotImplementedError:
+            not_implented = True
+
+        cls.device.device.current_test = ''
+        cls.device.device.current_test_case = ''
+
+        if not_implented:
+            pytest.skip("Method not implemented")
+        else:
+            return result
+
+    return wrapper
+
+
+class BaseTestGetters:
+    """Base class for testing drivers."""
+
+    @wrap_test_cases
+    def test_get_facts(self):
+        """Test get_facts method."""
+        facts = self.device.get_facts()
+        result = helpers.test_model(models.facts, facts)
+        assert result
+
+    @wrap_test_cases
+    def test_get_interfaces(self):
+        """Test get_interfaces method."""
+        get_interfaces = self.device.get_interfaces()
+        result = len(get_interfaces) > 0
+
+        for interface, interface_data in get_interfaces.iteritems():
+            result = result and helpers.test_model(models.interface, interface_data)
+
+        assert result
+
+    @wrap_test_cases
+    def test_get_bgp_neighbors(self):
+        """Test get_bgp_neighbors method."""
+        get_bgp_neighbors = self.device.get_bgp_neighbors()
+        result = 'global' in get_bgp_neighbors.keys()
+
+        if not result:
+            print('global is not part of the returned vrfs')
+        else:
+            for vrf, vrf_data in get_bgp_neighbors.iteritems():
+                result = result and isinstance(vrf_data['router_id'], unicode)
+                if not result:
+                    print('router_id is not unicode')
+
+                for peer, peer_data in vrf_data['peers'].iteritems():
+                    result = result and helpers.test_model(models.peer, peer_data)
+
+                    for af, af_data in peer_data['address_family'].iteritems():
+                        result = result and helpers.test_model(models.af, af_data)
+
+            assert result
+
+    @wrap_test_cases
+    def test_get_bgp_neighbors_detail(self):
+        """Test get_bgp_neighbors_detail method."""
+        get_bgp_neighbors_detail = self.device.get_bgp_neighbors_detail()
+
+        result = len(get_bgp_neighbors_detail) > 0
+
+        for remote_as, neighbor_list in get_bgp_neighbors_detail.iteritems():
+            for neighbor in neighbor_list:
+                result = result and helpers.test_model(models.peer_details, neighbor)
+
+        assert result

--- a/napalm_base/test/helpers.py
+++ b/napalm_base/test/helpers.py
@@ -1,0 +1,19 @@
+"""Several methods to help with the tests."""
+
+
+def test_model(model, data):
+    """Return if the dictionary `data` complies with the `model`."""
+    same_keys = set(model.keys()) == set(data.keys())
+
+    if not same_keys:
+        print("model_keys: {}\ndata_keys: {}".format(sorted(model.keys()), sorted(data.keys())))
+
+    correct_class = True
+    for key, instance_class in model.iteritems():
+        same_class = isinstance(data[key], instance_class)
+        correct_class = correct_class and same_class
+        if not same_class:
+            print("key: {}\nmodel_class: {}\ndata_class: {}".format(
+                                                    key, instance_class, data[key].__class__))
+
+    return correct_class and same_keys

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-pythonpath

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,7 @@
 pytest
+pytest-cov
+pytest-json
 pytest-pythonpath
+pylama
+flake8-import-order
+-r requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[pylama]
+linters = mccabe,pep257,pep8,pyflakes,import_order
+ignore = D203
+
+[pylama:pep8]
+max_line_length = 100

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ __author__ = 'David Barroso <dbarrosop@dravetech.com>'
 install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
 reqs = [str(ir.req) for ir in install_reqs]
 
+
 setup(
     name="napalm-base",
     version="0.15.0",


### PR DESCRIPTION
This is the new testing framework. It's based on py.test this time because I think it's way more interesting and powerful than the rest. This is how it works:

1. To mock tests create a folder with the test name. Inside create as many folders as you want with different name, each one containing different mocked data. The result will be that for each subfolder a different test case will be generated. See https://github.com/dbarrosop/napalm-eos/tree/test_framework/test/unit/mocked_data
1. If there is no test folder that means is used by the `open` function.
1. I have grouped functions that we were rewriting all the time. For example, how to read a json or a text file. See https://github.com/dbarrosop/napalm-base/blob/test_framework/napalm_base/test/double.py
1. Instead of editing files, to control wether to run the test with mocked data or what is the username, password, etc., we can use env variables. See https://github.com/dbarrosop/napalm-base/blob/test_framework/napalm_base/test/conftest.py#L6
1. The `NotImplemented` check for the tests is done with a decorator. The decorator does more stuff as well, like setting some parameters to figure out the test case. See https://github.com/dbarrosop/napalm-base/blob/test_framework/napalm_base/test/getters.py#L13

This is the result of an execution:

```
py.test test/unit/test_getters.py -v
==================================================================== test session starts =====================================================================
platform darwin -- Python 2.7.11, pytest-2.9.1, py-1.4.31, pluggy-0.3.1 -- /Users/dbarroso/.virtualenvs/napalm/bin/python2.7
cachedir: .cache
rootdir: /Users/dbarroso/workspace/napalm/napalm-eos, inifile: setup.cfg
plugins: pylama-7.0.7, pythonpath-0.7
collecting 0 items
[NAPALM] We failed to find test cases for test_get_bgp_neighbors. Please, add test cases in /Users/dbarroso/workspace/napalm/napalm-eos/test/unit/mocked_data/test_get_bgp_neighbors
collected 5 items

test/unit/test_getters.py::TestGetter::test_get_bgp_neighbors_detail[empty_case] <- ../napalm-base/napalm_base/test/getters.py SKIPPED
test/unit/test_getters.py::TestGetter::test_get_interfaces[normal] <- ../napalm-base/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_bgp_neighbors[test_case0] <- ../napalm-base/napalm_base/test/getters.py SKIPPED
test/unit/test_getters.py::TestGetter::test_get_facts[something] <- ../napalm-base/napalm_base/test/getters.py PASSED
test/unit/test_getters.py::TestGetter::test_get_facts[something_else] <- ../napalm-base/napalm_base/test/getters.py PASSED

============================================================ 3 passed, 2 skipped in 0.01 seconds =============================================================
```

Test `test/unit/test_getters.py::TestGetter::test_get_bgp_neighbors_detail[empty_case]` is skipped because there the method returns a `NotImplemented` exception and `test/unit/test_getters.py::TestGetter::test_get_bgp_neighbors` because there is not test case defined. Not that there is a log entry notifying about that:

`[NAPALM] We failed to find test cases for test_get_bgp_neighbors. Please, add test cases in /Users/dbarroso/workspace/napalm/napalm-eos/test/unit/mocked_data/test_get_bgp_neighbors`

See napalm-automation/napalm-eos#25 for details on how to implement this on a driver.