### PR TITLE
Fix so that textfsm_extractor() does not clobber all types to string.

### DIFF
--- a/napalm_base/helpers.py
+++ b/napalm_base/helpers.py
@@ -114,7 +114,7 @@ def textfsm_extractor(cls, template_name, raw_text):
         index = 0
         entry = {}
         for entry_value in obj:
-            entry[fsm_handler.header[index].lower()] = str(entry_value)
+            entry[fsm_handler.header[index].lower()] = entry_value
             index += 1
         textfsm_data.append(entry)
 


### PR DESCRIPTION
When using the following template:

```
Value Required if_name (.+)
Value flags (.+)
Value mtu (\d+)
Value qdisc (.+)
Value state (\w+)
Value link_type (.+)
Value mac_address (.+)
Value List ipv4_addresses (.+)
Value List ipv6_addresses (.+)

Start
	^\d+: [^:]+\: < -> Continue.Record
	^\d+: ${if_name}\: <${flags}> mtu ${mtu} qdisc ${qdisc} state ${state}
	^\s+link/${link_type}\s+${mac_address}\s+brd
	^\s+inet ${ipv4_addresses}\s+scope 
	^\s+inet6 ${ipv6_addresses}\s+scope 
```

against this input:

```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 16436 qdisc noqueue state UNKNOWN 
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
    inet 10.65.0.1/32 scope global lo
    inet 10.65.0.254/32 scope global lo
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 00:0c:29:cb:3a:5c brd ff:ff:ff:ff:ff:ff
    inet 192.168.144.111/24 scope global eth0
    inet6 fe80::20c:29ff:fecb:3a5c/64 scope link 
       valid_lft forever preferred_lft forever
3: swp1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 2000 qdisc pfifo_fast state UP qlen 1000
    link/ether 00:0c:29:cb:3a:66 brd ff:ff:ff:ff:ff:ff
    inet 10.129.0.1/30 scope global swp1
    inet6 fe80::20c:29ff:fecb:3a66/64 scope link 
       valid_lft forever preferred_lft forever
4: swp2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 2000 qdisc pfifo_fast state UP qlen 1000
    link/ether 00:0c:29:cb:3a:70 brd ff:ff:ff:ff:ff:ff
    inet 10.129.0.9/30 scope global swp2
    inet6 fe80::20c:29ff:fecb:3a70/64 scope link 
       valid_lft forever preferred_lft forever
5: swp3: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
    link/ether 00:0c:29:cb:3a:7a brd ff:ff:ff:ff:ff:ff
6: swp4: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
    link/ether 00:0c:29:cb:3a:84 brd ff:ff:ff:ff:ff:ff
7: swp5: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
    link/ether 00:0c:29:cb:3a:8e brd ff:ff:ff:ff:ff:ff
8: swp6: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
    link/ether 00:0c:29:cb:3a:98 brd ff:ff:ff:ff:ff:ff
9: swp7: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
    link/ether 00:0c:29:cb:3a:a2 brd ff:ff:ff:ff:ff:ff
```

The ipv4_address (and ipv6_address) values are returned as a list. However, in textfsm_extractor() all returned values are clobbered to str() type.

This small fix removes this and leaves them as the returned type instead.