### PR TITLE
New helper: mac

### DIFF
--- a/napalm_base/helpers.py
+++ b/napalm_base/helpers.py
@@ -7,11 +7,29 @@ import sys
 # third party libs
 import jinja2
 import textfsm
+from netaddr import EUI
+from netaddr import mac_unix
+from netaddr.core import AddrFormatError
 
 # local modules
 import napalm_base.exceptions
 
 from napalm_base.utils.jinja_filters import CustomJinjaFilters
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# helper classes -- will not be exported
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+class _MACFormat(mac_unix):
+    pass
+
+_MACFormat.word_fmt = '%.2X'
+
+# ----------------------------------------------------------------------------------------------------------------------
+# callable helpers
+# ----------------------------------------------------------------------------------------------------------------------
 
 
 def load_template(cls, template_name, template_source=None, template_path=None,
@@ -167,3 +185,30 @@ def convert(to, who, default=u''):
         return to(who)
     except:
         return default
+
+
+def mac(raw):
+
+    """
+    Converts a raw string to a standardised MAC Address EUI Format.
+
+    :param raw: the raw string containing the value of the MAC Address
+    :return: a string with the MAC Address in EUI format
+
+    Example:
+
+    .. code-block:: python
+
+        >>> mac('0123.4567.89ab')
+        u'01:23:45:67:89:AB'
+    """
+
+    mac = ''
+
+    try:
+        mac = unicode(EUI(raw, dialect=_MACFormat))
+    except AddrFormatError:
+        return ''
+
+    return mac
+

--- a/napalm_base/helpers.py
+++ b/napalm_base/helpers.py
@@ -160,11 +160,11 @@ def find_txt(xml_tree, path, default=''):
             if isinstance(xpath_result, type(xml_tree)):
                 value = xpath_result.text.strip()
             else:
-                value = str(xpath_result)
+                value = xpath_result
     except Exception:  # in case of any exception, returns default
         value = default
 
-    return value
+    return unicode(value)
 
 
 def convert(to, who, default=u''):

--- a/test/unit/TestHelpers.py
+++ b/test/unit/TestHelpers.py
@@ -272,6 +272,20 @@ class TestBaseHelpers(unittest.TestCase):
                            ) > 0
                        )
 
+    def test_mac(self):
+
+        """
+        Tests the helper function ```mac```:
+
+            * check if empty reply when invalid MAC
+            * check if MAC address returned as expected
+        """
+
+        self.assertEqual(napalm_base.helpers.mac('fake'), '')
+        self.assertEqual(napalm_base.helpers.mac('0123456789ab'), '01:23:45:67:89:AB')
+        self.assertEqual(napalm_base.helpers.mac('0123.4567.89ab'), '01:23:45:67:89:AB')
+        self.assertEqual(napalm_base.helpers.mac('123.4567.89ab'), '01:23:45:67:89:AB')
+
 
 class FakeNetworkDriver(NetworkDriver):
 


### PR DESCRIPTION
I think it's time to have a standard in the format of the MAC Addresses.
Easy to use:

```python
from napalm_base.helper import mac
mac('0123.4567.89ab')
```