### PR TITLE
Added missing requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-jinja2
-pyangbind
 gtextfsm
+jinja2
+netaddr
+pyangbind

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ reqs = [str(ir.req) for ir in install_reqs]
 
 setup(
     name="napalm-base",
-    version="0.15.0",
+    version="0.15.1",
     packages=find_packages(),
     author="David Barroso",
     author_email="dbarrosop@dravetech.com",


### PR DESCRIPTION
Seems like `netaddr` was missing from the `requirements.txt` file.

Will release a quick fix once this is approved.