### PR TITLE
Add find_version to napalm_base

### DIFF
--- a/napalm_base/__init__.py
+++ b/napalm_base/__init__.py
@@ -20,6 +20,7 @@ import inspect
 import importlib
 
 # NAPALM base
+__version__ = '0.15.1'
 from napalm_base.base import NetworkDriver
 from napalm_base.exceptions import ModuleImportError
 

--- a/napalm_base/helpers.py
+++ b/napalm_base/helpers.py
@@ -3,6 +3,7 @@
 # std libs
 import os
 import sys
+import re
 
 # third party libs
 import jinja2
@@ -30,7 +31,22 @@ _MACFormat.word_fmt = '%.2X'
 # ----------------------------------------------------------------------------------------------------------------------
 # callable helpers
 # ----------------------------------------------------------------------------------------------------------------------
+def find_version(*file_paths):
+    """
+    This pattern was modeled on a method from the Python Packaging User Guide:
+        https://packaging.python.org/en/latest/single_source_version.html
 
+    We read instead of importing so we don't get import errors if our code
+    imports from dependencies listed in install_requires.
+    """
+    base_module_file = os.path.join(*file_paths)
+    with open(base_module_file) as f:
+        base_module_data = f.read()
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              base_module_data, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
 
 def load_template(cls, template_name, template_source=None, template_path=None,
                   openconfig=False, **template_vars):

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,14 @@
 """setup.py file."""
-
 import uuid
-import os
-import re
 
 from setuptools import setup, find_packages
 from pip.req import parse_requirements
+from napalm_base.helpers import find_version
 
 __author__ = 'David Barroso <dbarrosop@dravetech.com>'
 
 install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
 reqs = [str(ir.req) for ir in install_reqs]
-
-def find_version(*file_paths):
-    """
-    This pattern was modeled on a method from the Python Packaging User Guide:
-        https://packaging.python.org/en/latest/single_source_version.html
-
-    We read instead of importing so we don't get import errors if our code
-    imports from dependencies listed in install_requires.
-    """
-    base_module_file = os.path.join(*file_paths)
-    with open(base_module_file) as f:
-        base_module_data = f.read()
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              base_module_data, re.M)
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
 
 setup(
     name="napalm-base",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 """setup.py file."""
 
 import uuid
+import os
+import re
 
 from setuptools import setup, find_packages
 from pip.req import parse_requirements
@@ -10,9 +12,26 @@ __author__ = 'David Barroso <dbarrosop@dravetech.com>'
 install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
 reqs = [str(ir.req) for ir in install_reqs]
 
+def find_version(*file_paths):
+    """
+    This pattern was modeled on a method from the Python Packaging User Guide:
+        https://packaging.python.org/en/latest/single_source_version.html
+
+    We read instead of importing so we don't get import errors if our code
+    imports from dependencies listed in install_requires.
+    """
+    base_module_file = os.path.join(*file_paths)
+    with open(base_module_file) as f:
+        base_module_data = f.read()
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              base_module_data, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 setup(
     name="napalm-base",
-    version="0.15.0",
+    version=find_version('napalm_base', '__init__.py'),
     packages=find_packages(),
     author="David Barroso",
     author_email="dbarrosop@dravetech.com",


### PR DESCRIPTION
Added find_version() to both the setup.py file for napalm_base and to helpers.py.

Other packages should just be able to add the following into their setup.py

```
from napalm_base.helpers import find_version
```