### PR TITLE
We need those system helpers to work without importing 3d party libraries

### DIFF
--- a/napalm_base/__init__.py
+++ b/napalm_base/__init__.py
@@ -20,7 +20,7 @@ import inspect
 import importlib
 
 # NAPALM base
-__version__ = '0.16.0'
+__version__ = '0.16.1'
 from napalm_base.base import NetworkDriver
 from napalm_base.exceptions import ModuleImportError
 

--- a/napalm_base/helpers.py
+++ b/napalm_base/helpers.py
@@ -31,22 +31,6 @@ _MACFormat.word_fmt = '%.2X'
 # ----------------------------------------------------------------------------------------------------------------------
 # callable helpers
 # ----------------------------------------------------------------------------------------------------------------------
-def find_version(*file_paths):
-    """
-    This pattern was modeled on a method from the Python Packaging User Guide:
-        https://packaging.python.org/en/latest/single_source_version.html
-
-    We read instead of importing so we don't get import errors if our code
-    imports from dependencies listed in install_requires.
-    """
-    base_module_file = os.path.join(*file_paths)
-    with open(base_module_file) as f:
-        base_module_data = f.read()
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              base_module_data, re.M)
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
 
 def load_template(cls, template_name, template_source=None, template_path=None,
                   openconfig=False, **template_vars):

--- a/napalm_base/system_helpers.py
+++ b/napalm_base/system_helpers.py
@@ -1,0 +1,22 @@
+"""Useful helpers for basic stuff like parsing module version."""
+
+import os
+import re
+
+
+def find_version(*file_paths):
+    """
+    This pattern was modeled on a method from the Python Packaging User Guide:
+        https://packaging.python.org/en/latest/single_source_version.html
+
+    We read instead of importing so we don't get import errors if our code
+    imports from dependencies listed in install_requires.
+    """
+    base_module_file = os.path.join(*file_paths)
+    with open(base_module_file) as f:
+        base_module_data = f.read()
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              base_module_data, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import uuid
 
 from setuptools import setup, find_packages
 from pip.req import parse_requirements
-from napalm_base.helpers import find_version
+from napalm_base import system_helpers
 
 __author__ = 'David Barroso <dbarrosop@dravetech.com>'
 
@@ -12,7 +12,7 @@ reqs = [str(ir.req) for ir in install_reqs]
 
 setup(
     name="napalm-base",
-    version=find_version('napalm_base', '__init__.py'),
+    version=system_helpers.find_version('napalm_base', '__init__.py'),
     packages=find_packages(),
     author="David Barroso",
     author_email="dbarrosop@dravetech.com",


### PR DESCRIPTION
```
$ pip install -r requirements.txt
Collecting napalm-base (from -r requirements.txt (line 1))
  Downloading napalm-base-0.16.0.tar.gz (232kB)
    100% |################################| 233kB 1.8MB/s 
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-3bUemy/napalm-base/setup.py", line 6, in <module>
        from napalm_base.helpers import find_version
      File "napalm_base/__init__.py", line 24, in <module>
        from napalm_base.base import NetworkDriver
      File "napalm_base/base.py", line 20, in <module>
        import napalm_base.helpers
      File "napalm_base/helpers.py", line 9, in <module>
        import jinja2
    ImportError: No module named jinja2
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
    
      File "<string>", line 20, in <module>
    
      File "/tmp/pip-build-3bUemy/napalm-base/setup.py", line 6, in <module>
    
        from napalm_base.helpers import find_version
    
      File "napalm_base/__init__.py", line 24, in <module>
    
        from napalm_base.base import NetworkDriver
    
      File "napalm_base/base.py", line 20, in <module>
    
        import napalm_base.helpers
    
      File "napalm_base/helpers.py", line 9, in <module>
    
        import jinja2
    
    ImportError: No module named jinja2
    
    ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-3bUemy/napalm-base
The command "pip install -r requirements.txt" failed and exited with 1 during .
```