### PR TITLE
Adding validation capabilities to the napalm-base

### DIFF
--- a/napalm_base/exceptions.py
+++ b/napalm_base/exceptions.py
@@ -51,3 +51,6 @@ class TemplateNotImplemented(Exception):
 
 class TemplateRenderException(Exception):
     pass
+
+class ValidationException(Exception):
+    pass

--- a/napalm_base/validate.py
+++ b/napalm_base/validate.py
@@ -108,7 +108,54 @@ def _find_config_differences(actual_config, expected_config):
 
     return not_matched
 
-def validate(cls, getters=None, config=None, validation_file='validate.yml'):
+def validate(cls, getters=None, config=None, validation_file=None):
+    """
+    Validate getter methods outputs and configurations comparing them with a validation
+    YAML file containing expected results.
+
+    In order to validate getter methods, YAML file's keys have to match the getter
+    method's name willing to validate and its values structure must reflect the getter
+    output format.
+
+    Example:
+    ---
+
+    get_bgp_neighbors:
+      default:
+        router_id: 192.0.2.2
+        peers:
+          192.0.2.3:
+            is_enabled: false
+
+    get_interfaces:
+      Ethernet2/5:
+        is_enabled: true
+        is_up: true
+
+      Vlan100:
+        is_enabled: false
+        is_up: false
+
+    In order to validate configuration, the YAML file must contain keys like 'running'
+    or 'candidate' and their content must be a list of configuration lines that must be
+    present in the configuration. To do that, get_config() method must be supported by
+    the network driver.
+
+    Example:
+    ---
+
+    running:
+      - username napalm password napalm
+
+    This method will return True if a full match between expected and actual results
+    is found. Otherwise, it will return a dictionary showing not matched values.
+
+    :param cls: Instance of the driver class
+    :param getters: Specifies the name of the getter function to be tested.
+    :param config: Either 'running' or 'candidate', specifying which configuration should be tested. 
+    :param validation_file: Name of the YAML file used for the validation.
+    :return: True if a full match is found, Otherwise, it will return a dictionary.
+    """
     errors = {}
     if getters:
         getters = _check_getters(cls, getters)

--- a/napalm_base/validate.py
+++ b/napalm_base/validate.py
@@ -1,3 +1,5 @@
+"""Validation methods for the NAPALM base."""
+
 import yaml
 
 from napalm_base.exceptions import ValidationException
@@ -13,10 +15,12 @@ def _check_getters(cls, getters):
 
     return getters
 
+
 def _check_config(config):
     if config not in ['running', 'candidate']:
         raise ValidationException("{0} config not supported. Only running or "
                                   "candidate are allowed".format(config))
+
 
 def _get_validation_file(validation_file):
     try:
@@ -40,11 +44,12 @@ def _find_differences(cls, key, actual_value, expected_values):
 
     elif (isinstance(actual_value, unicode) or
           isinstance(actual_value, int)):
-        not_matched_result = _handle_unicode_int(key, actual_value, expected_values[key])
+        not_matched_result = _handle_unicode_int(actual_value, expected_values[key])
 
     elif isinstance(actual_value, list):
-        not_matched_result = _handle_list(key, actual_value, expected_values[key])
+        not_matched_result = _handle_list(actual_value, expected_values[key])
     return not_matched_result
+
 
 def _handle_dict(cls, actual_values, expected_values):
     not_matched = []
@@ -71,14 +76,16 @@ def _handle_dict(cls, actual_values, expected_values):
                 not_matched.append(not_matched_string)
     return not_matched
 
-def _handle_unicode_int(key, actual_values, expected_values):
+
+def _handle_unicode_int(actual_values, expected_values):
     not_matched_string = ''
     if str(actual_values) != str(expected_values):
         not_matched_string = ("Expected '{0}', "
                               "found '{1}' instead".format(expected_values, actual_values))
     return not_matched_string
 
-def _handle_list(key, actual_values, expected_values):
+
+def _handle_list(actual_values, expected_values):
     not_matched = []
     not_matched_string = ''
     for value in expected_values:
@@ -99,6 +106,7 @@ def _handle_list(key, actual_values, expected_values):
 
     return not_matched
 
+
 def _find_config_differences(actual_config, expected_config):
     not_matched = []
 
@@ -107,6 +115,7 @@ def _find_config_differences(actual_config, expected_config):
             not_matched.append(config_line)
 
     return not_matched
+
 
 def validate(cls, getters=None, config=None, validation_file=None):
     """
@@ -180,13 +189,12 @@ def validate(cls, getters=None, config=None, validation_file=None):
             for key in expected_results.keys():
                 not_matched_result = ''
                 not_matched = []
-                expected_values = expected_results[key]
                 actual_values = actual_results.get(key)
                 not_matched_result = _find_differences(cls, key, actual_values, expected_results)
 
                 if not_matched_result:
                     if (isinstance(not_matched_result, dict) or
-                        isinstance(not_matched_result, str)):
+                            isinstance(not_matched_result, str)):
                         not_matched.append(not_matched_result)
                     else:
                         not_matched.extend(not_matched_result)
@@ -205,7 +213,7 @@ def validate(cls, getters=None, config=None, validation_file=None):
                                       ' Check your syntax.'.format(config))
 
         actual_config = cls.get_config(retrieve=config)[config]
-        not_matched_result = _find_config_differences(cls, actual_config, expected_config)
+        not_matched_result = _find_config_differences(actual_config, expected_config)
 
         if not_matched_result:
             error_string = "Expected but not found in {0} config".format(config)

--- a/napalm_base/validate.py
+++ b/napalm_base/validate.py
@@ -147,12 +147,9 @@ def validate(cls, getters=None, config=None, validation_file=None):
     running:
       - username napalm password napalm
 
-    This method will return True if a full match between expected and actual results
-    is found. Otherwise, it will return a dictionary showing not matched values.
-
     :param cls: Instance of the driver class
     :param getters: Specifies the name of the getter function to be tested.
-    :param config: Either 'running' or 'candidate', specifying which configuration should be tested. 
+    :param config: Either 'running' or 'candidate', specifying which config should be tested.
     :param validation_file: Name of the YAML file used for the validation.
     :return: True if a full match is found, Otherwise, it will return a dictionary.
     """

--- a/napalm_base/validate.py
+++ b/napalm_base/validate.py
@@ -1,0 +1,173 @@
+import yaml
+
+from napalm_base.exceptions import ValidationException
+
+
+def _check_getters(cls, getters):
+    if isinstance(getters, str):
+        getters = [getters]
+
+    for getter in getters:
+        if (getter.startswith('get_') and getter in dir(cls)) is False:
+            raise ValidationException("{0} method not found.".format(getter))
+
+    return getters
+
+def _check_config(config):
+    if config not in ['running', 'candidate']:
+        raise ValidationException("{0} config not supported. Only running or "
+                                  "candidate are allowed".format(config))
+
+def _get_validation_file(validation_file):
+    try:
+        with open(validation_file, 'r') as stream:
+            try:
+                validation_source = yaml.load(stream)
+            except yaml.YAMLError, exc:
+                raise ValidationException(exc)
+    except IOError:
+        raise ValidationException("File {0} not found.".format(validation_file))
+    return validation_source
+
+
+def _find_differences(cls, key, actual_value, expected_values):
+    not_matched_result = ''
+    if actual_value is None:
+        not_matched_result = "Expected key but not found."
+
+    if isinstance(actual_value, dict):
+        not_matched_result = _handle_dict(cls, actual_value, expected_values[key])
+
+    elif (isinstance(actual_value, unicode) or
+          isinstance(actual_value, int)):
+        not_matched_result = _handle_unicode_int(key, actual_value, expected_values[key])
+
+    elif isinstance(actual_value, list):
+        not_matched_result = _handle_list(key, actual_value, expected_values[key])
+    return not_matched_result
+
+def _handle_dict(cls, actual_values, expected_values):
+    not_matched = []
+    not_matched_dict = {}
+    try:
+        delta = dict(set(expected_values.iteritems()).difference(actual_values.iteritems()))
+    except TypeError:
+        for key in expected_values.keys():
+            actual_value = actual_values.get(key)
+
+            not_matched_result = _find_differences(cls, key, actual_value, expected_values)
+            if not_matched_result:
+                not_matched_dict[key] = not_matched_result
+
+        return not_matched_dict
+
+    if delta:
+        for delta_key in delta.keys():
+            not_matched_string = ''
+            not_matched_string = ("Expected '{0}: {1}', found '{2}: {3}' "
+                                  "instead".format(delta_key, delta[delta_key],
+                                                   delta_key, actual_values[delta_key]))
+            if not_matched_string:
+                not_matched.append(not_matched_string)
+    return not_matched
+
+def _handle_unicode_int(key, actual_values, expected_values):
+    not_matched_string = ''
+    if str(actual_values) != str(expected_values):
+        not_matched_string = ("Expected '{0}', "
+                              "found '{1}' instead".format(expected_values, actual_values))
+    return not_matched_string
+
+def _handle_list(key, actual_values, expected_values):
+    not_matched = []
+    not_matched_string = ''
+    for value in expected_values:
+        if isinstance(value, dict):
+            found = False
+            for act_values in actual_values:
+                delta = dict(set(value.iteritems()).difference(act_values.iteritems()))
+                if not delta:
+                    found = True
+            if found is False:
+                not_matched_string = ("Expected but not found: {0}".format(value, actual_values))
+        else:
+            if value not in actual_values:
+                not_matched_string = ("Expected but not found: {0}".format(value, actual_values))
+
+        if not_matched_string:
+            not_matched.append(not_matched_string)
+
+    return not_matched
+
+def _find_config_differences(actual_config, expected_config):
+    not_matched = []
+
+    for config_line in expected_config:
+        if config_line not in actual_config:
+            not_matched.append(config_line)
+
+    return not_matched
+
+def validate(cls, getters=None, config=None, validation_file='validate.yml'):
+    errors = {}
+    if getters:
+        getters = _check_getters(cls, getters)
+
+    if config:
+        _check_config(config)
+
+    validation_source = _get_validation_file(validation_file)
+
+    if getters:
+        for getter in getters:
+            not_matched_getter = {}
+
+            try:
+                expected_results = validation_source[getter]
+            except KeyError:
+                raise ValidationException('{0} key not found in validation file.'
+                                          ' Check your syntax.'.format(getter))
+
+            actual_results = getattr(cls, getter)()
+            if isinstance(actual_results, list):
+                actual_results = dict(not_matched=actual_results)
+                expected_results = dict(not_matched=expected_results)
+
+            for key in expected_results.keys():
+                not_matched_result = ''
+                not_matched = []
+                expected_values = expected_results[key]
+                actual_values = actual_results.get(key)
+                not_matched_result = _find_differences(cls, key, actual_values, expected_results)
+
+                if not_matched_result:
+                    if (isinstance(not_matched_result, dict) or
+                        isinstance(not_matched_result, str)):
+                        not_matched.append(not_matched_result)
+                    else:
+                        not_matched.extend(not_matched_result)
+
+                if not_matched:
+                    not_matched_getter[key] = not_matched
+
+            if not_matched_getter:
+                errors[getter] = not_matched_getter
+
+    elif config:
+        try:
+            expected_config = validation_source[config]
+        except KeyError:
+            raise ValidationException('{0} key not found in validation file.'
+                                      ' Check your syntax.'.format(config))
+
+        actual_config = cls.get_config(retrieve=config)[config]
+        not_matched_result = _find_config_differences(cls, actual_config, expected_config)
+
+        if not_matched_result:
+            error_string = "Expected but not found in {0} config".format(config)
+            errors[error_string] = not_matched_result
+
+    if not errors:
+        return True
+    else:
+        return errors


### PR DESCRIPTION
Refers to #83

Here I'm adding validation capabilities to napalm-base. This means that we'll be able to validate getters method results and running/candidate configuration as well.

Sample `validate.yml`

```

---

get_interfaces:
  Ethernet2/5:
    is_enabled: true
    is_up: false

  loopback103:
    is_enabled: false
    is_up: false

  Vlan100:
    is_enabled: false
    is_up: false

get_facts:
  os_version: 7.0(3)I2(2d)
  interface_list:
    - Vlan5
    - Vlan100
  hostname: n9k2

get_lldp_neighbors:
  mgmt0:
    - hostname: PERIMETER
      port: Fa1/0/3
    - hostname: nxos-spine2
      port: nxos-spine2

get_bgp_neighbors:
  default:
    router_id: 192.0.2.2
    peers:
      192.0.2.3:
        is_enabled: false
      192.0.2.2:
        is_enabled: false
        address_family:
          ipv4:
            sent_prefixes: 5
          ipv6:
            sent_prefixes: 2

get_arp_table:
  - interface: Ethernet2/1
    ip: 192.0.2.2

get_interfaces_ip:
  Ethernet2/1:
    ipv4:
      192.0.2.1:
        prefix_length: 30

running:
  - username gabriele password gabriele
  - interface Ethernet2/1
```

Sample implementation into NXOS driver:

```
    def validate(self, getters=None, config=None, validation_file='validate.yml'):
        errors = napalm_base.validate.validate(self, getters=getters, config=config, validation_file=validation_file)
        return errors
```

Sample workflow:

```
>>>import json
>>>from napalm import get_network_driver
>>>driver = get_network_driver('nxos')
>>>device = driver('nxos', 'ntc', 'ntc123')
>>>device.open()
>>>
>>>getters = ['get_facts', 'get_lldp_neighbors', 'get_bgp_neighbors', 'get_interfaces', 'get_interfaces_ip']
>>>validation = device.validate(getters=getters)
>>>
>>>print json.dumps(validation, indent=4)
```

Sample results:

```
{
    "get_facts": {
        "os_version": [
            "Expected key but not found."
        ], 
        "interface_list": [
            "Expected but not found: Vlan5", 
            "Expected but not found: Vlan100"
        ], 
        "hostname": [
            "Expected 'n9k2', found 'nxos-spine1' instead"
        ]
    }, 
    "get_interfaces": {
        "Ethernet2/5": [
            "Expected 'is_up: False', found 'is_up: True' instead"
        ], 
        "Vlan100": [
            "Expected key but not found."
        ], 
        "loopback103": [
            "Expected key but not found."
        ]
    }, 
    "get_interfaces_ip": {
        "Ethernet2/1": [
            {
                "ipv4": {
                    "192.0.2.1": [
                        "Expected 'prefix_length: 30', found 'prefix_length: 24' instead"
                    ]
                }
            }
        ]
    }, 
    "get_lldp_neighbors": {
        "mgmt0": [
            "Expected key but not found."
        ]
    }, 
    "get_bgp_neighbors": {
        "default": [
            {
                "router_id": "Expected '192.0.2.2', found '192.0.2.1' instead", 
                "peers": {
                    "192.0.2.3": "Expected key but not found.", 
                    "192.0.2.2": {
                        "is_enabled": "Expected 'False', found 'True' instead", 
                        "address_family": {
                            "ipv4": [
                                "Expected 'sent_prefixes: 5', found 'sent_prefixes: -1' instead"
                            ], 
                            "ipv6": "Expected key but not found."
                        }
                    }
                }
            }
        ]
    }
}
```

Later or tomorrow I'll add a sample workflow for configuration as well.
Any suggestion is welcome :)
