### PR TITLE
Add method .get_vrfs()

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1380,29 +1380,52 @@ class NetworkDriver(object):
         """
         raise NotImplementedError
 
-    def get_vrfs(self):
+    def get_network_instances(self, name=''):
         """
-        Return a dictionary of VRFs configured on the device, including default/global
-        The keys of the main dictionary represent the name of the VRF.  The values are as below:
-            * route_distinguisher (unicode or None)
-            * interfaces (list of unicodes)
+        Return a dictionary of network instances (VRFs) configured on the device, including default/global
+
+        Args:
+            name(string) - Name of the network instance to return, default is all.
+
+        Returns:
+            A dictionary of network instances in OC format:
+            * name (dict)
+              * name (unicode)
+              * type (unicode, fixed to L3VRF)
+              * state (dict)
+                * route_distinguisher (unicode or None)
+              * interfaces (dict)
+                * interface (dict)
+                  * interface name: (dict)
 
         Example:
         {
             u'MGMT': {
-                u'route_distinguisher': u'123:456',
-                u'interfaces': [
-                    u'Management1',
-                ]
+                u'name': u'MGMT',
+                u'type': u'L3VRF',
+                u'state': {
+                    u'route_distinguisher': u'123:456',
+                },
+                u'interfaces': {
+                    u'interface': {
+                        u'Management1': {}
+                    }
+                }
             }
             u'default': {
-                u'route_distinguisher': None,
-                u'interfaces: [
-                    u'Ethernet1',
-                    u'Ethernet2',
-                    u'Ethernet3',
-                    u'Ethernet4',
-                ]
+                u'name': u'default',
+                u'type': u'L3VRF',
+                u'state': {
+                    u'route_distinguisher': None,
+                },
+                u'interfaces: {
+                    u'interface': {
+                        u'Ethernet1': {}
+                        u'Ethernet2': {}
+                        u'Ethernet3': {}
+                        u'Ethernet4': {}
+                    }
+                }
             }
         }
         """

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1382,7 +1382,7 @@ class NetworkDriver(object):
 
     def get_network_instances(self, name=''):
         """
-        Return a dictionary of network instances (VRFs) configured on the device, including default/global
+        Return a dictionary of network instances (VRFs) configured, including default/global
 
         Args:
             name(string) - Name of the network instance to return, default is all.

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1379,3 +1379,31 @@ class NetworkDriver(object):
               empty string
         """
         raise NotImplementedError
+
+    def get_vrfs(self):
+        """
+        Return a dictionary of VRFs configured on the device, including default/global
+        The keys of the main dictionary represent the name of the VRF.  The values are as below:
+            * route_descriptor (unicode or None)
+            * interfaces (list of unicodes)
+
+        Example:
+        {
+            u'MGMT': {
+                u'route_descriptor': u'123:456',
+                u'interfaces': [
+                    u'Management1',
+                ]
+            }
+            u'default': {
+                u'route_descriptor': None,
+                u'interfaces: [
+                    u'Ethernet1',
+                    u'Ethernet2',
+                    u'Ethernet3',
+                    u'Ethernet4',
+                ]
+            }
+        }
+        """
+        raise NotImplementedError

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1384,19 +1384,19 @@ class NetworkDriver(object):
         """
         Return a dictionary of VRFs configured on the device, including default/global
         The keys of the main dictionary represent the name of the VRF.  The values are as below:
-            * route_descriptor (unicode or None)
+            * route_distinguisher (unicode or None)
             * interfaces (list of unicodes)
 
         Example:
         {
             u'MGMT': {
-                u'route_descriptor': u'123:456',
+                u'route_distinguisher': u'123:456',
                 u'interfaces': [
                     u'Management1',
                 ]
             }
             u'default': {
-                u'route_descriptor': None,
+                u'route_distinguisher': None,
                 u'interfaces: [
                     u'Ethernet1',
                     u'Ethernet2',

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1391,7 +1391,7 @@ class NetworkDriver(object):
             A dictionary of network instances in OC format:
             * name (dict)
               * name (unicode)
-              * type (unicode, fixed to L3VRF)
+              * type (unicode)
               * state (dict)
                 * route_distinguisher (unicode or None)
               * interfaces (dict)
@@ -1414,7 +1414,7 @@ class NetworkDriver(object):
             }
             u'default': {
                 u'name': u'default',
-                u'type': u'L3VRF',
+                u'type': u'DEFAULT_INSTANCE',
                 u'state': {
                     u'route_distinguisher': None,
                 },

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -541,5 +541,9 @@ class TestGettersNetworkDriver(object):
         result = isinstance(get_network_instances, dict)
         for network_instance_name, network_instance in get_network_instances.items():
             result = result and self._test_model(models.network_instance, network_instance)
+            result = result and \
+                self._test_model(models.network_instance_state, network_instance['state'])
+            result = result and \
+                self._test_model(models.network_instance_interfaces, network_instance['interfaces'])
 
         self.assertTrue(result)

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -530,3 +530,16 @@ class TestGettersNetworkDriver(object):
             assert get_config['candidate'] == "" if config != "candidate" else True
             assert get_config['startup'] == "" if config != "startup" else True
             assert get_config['running'] == "" if config != "running" else True
+
+    def test_get_network_instances(self):
+        """Test get_network_instances method."""
+        try:
+            get_network_instances = self.device.get_network_instances()
+        except NotImplementedError:
+            raise SkipTest()
+
+        result = isinstance(get_network_instances, dict)
+        for network_instance_name, network_instance in get_network_instances.items():
+            result = result and self._test_model(models.network_instance, network_instance)
+
+        self.assertTrue(result)

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -425,3 +425,14 @@ class BaseTestGetters(object):
             assert get_config['running'] == "" if config != "running" else True
 
         return get_config
+
+    @wrap_test_cases
+    def test_get_network_instances(self):
+        """Test get_network_instances method."""
+        get_network_instances = self.device.get_network_instances()
+
+        assert isinstance(get_network_instances, dict)
+        for network_instance_name, network_instance in get_network_instances:
+            assert helpers.test_model(models.network_instance, network_instance)
+
+        return get_network_instances

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -434,5 +434,8 @@ class BaseTestGetters(object):
         assert isinstance(get_network_instances, dict)
         for network_instance_name, network_instance in get_network_instances:
             assert helpers.test_model(models.network_instance, network_instance)
+            assert helpers.test_model(models.network_instance_state, network_instance['state'])
+            assert helpers.test_model(models.network_instance_interfaces,
+                                      network_instance['interfaces'])
 
         return get_network_instances

--- a/napalm_base/test/models.py
+++ b/napalm_base/test/models.py
@@ -304,3 +304,11 @@ network_instance = {
     'state': dict,
     'interfaces': dict,
 }
+
+network_instance_state = {
+    'route_descriptor': text_type,
+}
+
+network_instance_interfaces = {
+    'interface': dict,
+}

--- a/napalm_base/test/models.py
+++ b/napalm_base/test/models.py
@@ -297,3 +297,10 @@ config = {
     'startup': text_type,
     'candidate': text_type,
 }
+
+network_instance = {
+    'name': text_type,
+    'type': text_type,
+    'state': dict,
+    'interfaces': dict,
+}


### PR DESCRIPTION
Proposal to add a method to retrieve configured VRFs and their associated interfaces from a device.