### PR TITLE
Fix python3 import bug

### DIFF
--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -9,8 +9,8 @@ import os
 
 
 import pytest
-import napalm_base.test.helpers
-import napalm_base.test.models
+from napalm_base.test import helpers
+from napalm_base.test import models
 
 # text_type is 'unicode' for py2 and 'str' for py3
 from napalm_base.utils.py23_compat import text_type

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -8,9 +8,9 @@ import json
 import os
 
 
-import helpers
-import models
 import pytest
+import napalm_base.test.helpers
+import napalm_base.test.models
 
 # text_type is 'unicode' for py2 and 'str' for py3
 from napalm_base.utils.py23_compat import text_type


### PR DESCRIPTION
Previous import statement won't work under Python3. Was causing Python3 test failures in napalm-eos.