### PR TITLE
Strip more characters

### DIFF
--- a/napalm_base/test/double.py
+++ b/napalm_base/test/double.py
@@ -34,7 +34,7 @@ class BaseTestDouble(object):
     @staticmethod
     def sanitize_text(text):
         """Remove some weird characters from text, useful for building filenames from commands."""
-        regexp = r'[/\\*\^\+\s\|\/\$\%\!\"\<\>\:]'
+        regexp = r'[/\\*\^\+\s\|\/\$\%\!\"\<\>\:\.]'
         return re.sub(regexp, '_', text)[0:150]
 
     @staticmethod

--- a/napalm_base/test/double.py
+++ b/napalm_base/test/double.py
@@ -34,7 +34,7 @@ class BaseTestDouble(object):
     @staticmethod
     def sanitize_text(text):
         """Remove some weird characters from text, useful for building filenames from commands."""
-        regexp = r'[/\\*\^\+\s\|\/\$\%\!\"\<\>\:\.]'
+        regexp = '[^a-zA-Z0-9]'
         return re.sub(regexp, '_', text)[0:150]
 
     @staticmethod

--- a/napalm_base/test/double.py
+++ b/napalm_base/test/double.py
@@ -34,7 +34,7 @@ class BaseTestDouble(object):
     @staticmethod
     def sanitize_text(text):
         """Remove some weird characters from text, useful for building filenames from commands."""
-        regexp = r'[\[\]\*\^\+\s\|\/\$\%\!\"]'
+        regexp = r'[/\\*\^\+\s\|\/\$\%\!\"\<\>\:]'
         return re.sub(regexp, '_', text)[0:150]
 
     @staticmethod


### PR DESCRIPTION
Old behaviour:

```python
>>> text = 'my text has > and \ and $ ...'
>>> re.sub(regexp, '_', text)[0:150]
'my_text_has_>_and_\\_and___...'
```

New:

```python
>>> re.sub(regexp, '_', text)[0:150]
'my_text_has____and___and______'
```

Changes: ```\```, ```>```, ```<```, ```:``` and ```.``` are replaced now by ```_```.

The colon & period chars replacement will impact the existing tests under napalm-eos, and filenames under the tests for [get_bgp_neighbors](https://github.com/napalm-automation/napalm-eos/tree/develop/test/unit/mocked_data/test_get_bgp_neighbors) will need to be renamed, e.g.: https://github.com/napalm-automation/napalm-eos/blob/develop/test/unit/mocked_data/test_get_bgp_neighbors/normal/show_ip_bgp_neighbors_vrf_all___include_remote_AS___remote_router_ID__IPv_46__Unicast:.__0-9____Local_AS_Desc_BGP_state.text