### PR TITLE
New method: is_alive()

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -89,6 +89,16 @@ class NetworkDriver(object):
         """
         raise NotImplementedError
 
+    def is_alive(self):
+        """
+        Returns a flag with the connection state.
+        Depends on the nature of API used by each driver.
+        The state does not reflect only on the connection status (when SSH), it must also take into
+        consideration other parameters, e.g.: NETCONF session might not be usable, althought the
+        underlying SSH session is still open etc.
+        """
+        raise NotImplementedError
+
     def load_template(self, template_name, template_source=None,
                       template_path=None, **template_vars):
         """

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -166,6 +166,13 @@ class TestGettersNetworkDriver(object):
 
         return correct_class and same_keys
 
+    def test_is_alive(self):
+        try:
+            alive = self.device.is_alive()
+        except NotImplementedError:
+            raise SkipTest()
+        self.assertIsInstance(alive, bool, msg='`is_alive` must return a boolean value.')
+
     def test_get_facts(self):
         try:
             facts = self.device.get_facts()

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -171,7 +171,8 @@ class TestGettersNetworkDriver(object):
             alive = self.device.is_alive()
         except NotImplementedError:
             raise SkipTest()
-        self.assertIsInstance(alive, bool, msg='`is_alive` must return a boolean value.')
+        result = self._test_model(models.alive, alive)
+        self.assertTrue(result)
 
     def test_get_facts(self):
         try:

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -104,6 +104,12 @@ class BaseTestGetters(object):
     """Base class for testing drivers."""
 
     @wrap_test_cases
+    def test_is_alive(self):
+        """Test is_alive method."""
+        alive = self.device.is_alive()
+        assert isinstance(alive, bool)
+
+    @wrap_test_cases
     def test_get_facts(self):
         """Test get_facts method."""
         facts = self.device.get_facts()

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -107,7 +107,8 @@ class BaseTestGetters(object):
     def test_is_alive(self):
         """Test is_alive method."""
         alive = self.device.is_alive()
-        assert isinstance(alive, bool)
+        assert helpers.test_model(models.alive, alive)
+        return alive
 
     @wrap_test_cases
     def test_get_facts(self):

--- a/napalm_base/test/models.py
+++ b/napalm_base/test/models.py
@@ -2,6 +2,10 @@
 # text_type is 'unicode' for py2 and 'str' for py3
 from napalm_base.utils.py23_compat import text_type
 
+alive = {
+    'is_alive': bool
+}
+
 facts = {
     'os_version': text_type,
     'uptime': int,
@@ -12,6 +16,7 @@ facts = {
     'hostname': text_type,
     'fqdn': text_type
 }
+
 interface = {
     'is_up': bool,
     'is_enabled': bool,


### PR DESCRIPTION
There are cases when the connection is open correctly, the driver stays connected for minutes/hours/days, but due to external factors, the connection is dropped (packet loss, or the device simply kills the process etc.).
In that case, we need to know when the connection become unusable and reconnect.