### PR TITLE
Implementation of get_firewall_policies

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1452,27 +1452,19 @@ class NetworkDriver(object):
 
         Example:
         {
-            '1': {
-                'uuid': '9d747de8-dad4-51e5-7a7e-d078aa77140a',
-                'service': '"ALL"',
-                'schedule': '"always"',
-                'srcaddr': '"all"',
-                'dstintf': '"any"',
-                'srcintf': '"any"',
-                'action': 'accept',
-                'dstaddr': '"all"'
+            'src_zone-to-dst_zone': {
+                'position': 1,
+                'id': '230',
+                'enabled': True,
+                'schedule': 'Always',
+                'log': 'all',
+                'l3_src': 'any',
+                'l3_dst': 'any',
+                'service': 'HTTP',
+	            'src_zone': 'port2',
+            	'dst_zone': 'port3',
+	            'action': 'Permit'
             }
-            '2': {
-                'name': '"bla"',
-                'service': '"ALL"',
-                'schedule': '"always"',
-                'logtraffic': 'all',
-                'srcaddr': '"all"',
-                'dstintf': '"port2"',
-                'srcintf': '"port3"',
-                'dstaddr': '"all"',
-                'uuid': 'de597b64-aca8-51e6-5d00-b7874e6b72b8'
-           }
         }
         """
         raise NotImplementedError

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1443,8 +1443,8 @@ class NetworkDriver(object):
 
     def get_firewall_policies(self):
         """
-        Returns a dictionary of lists of dictionaries where the first key is an unique policy 
-	name and the inner dictionary contains the following keys:
+        Returns a dictionary of lists of dictionaries where the first key is an unique policy
+        name and the inner dictionary contains the following keys:
 
         * position (int)
         * id (text_type)

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1461,9 +1461,9 @@ class NetworkDriver(object):
                 'l3_src': 'any',
                 'l3_dst': 'any',
                 'service': 'HTTP',
-	            'src_zone': 'port2',
-            	'dst_zone': 'port3',
-	            'action': 'Permit'
+                'src_zone': 'port2',
+                'dst_zone': 'port3',
+                'action': 'Permit'
             }
         }
         """

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1440,3 +1440,39 @@ class NetworkDriver(object):
         }
         """
         raise NotImplementedError
+
+    def get_firewall_policies(self):
+        """
+        Return a dictionary of configured Firewall policies
+
+        Returns:
+            A dictionary of policies 
+            * name
+                * n amount of arguments
+
+        Example:
+        {
+            '1': {
+                'uuid': '9d747de8-dad4-51e5-7a7e-d078aa77140a',
+                'service': '"ALL"', 
+                'schedule': '"always"', 
+                'srcaddr': '"all"', 
+                'dstintf': '"any"', 
+                'srcintf': '"any"', 
+                'action': 'accept', 
+                'dstaddr': '"all"'
+            } 
+            '2': {
+                'name': '"bla"',
+                'service': '"ALL"',
+                'schedule': '"always"', 
+                'logtraffic': 'all',
+                'srcaddr': '"all"', 
+                'dstintf': '"port2"', 
+                'srcintf': '"port3"', 
+                'dstaddr': '"all"', 
+                'uuid': 'de597b64-aca8-51e6-5d00-b7874e6b72b8'
+           }
+        }
+        """
+        raise NotImplementedError 

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1456,7 +1456,7 @@ class NetworkDriver(object):
         * service (text_type)
         * src_zone (text_type)
         * dst_zone (text_type)
-        * action (text_type)        
+        * action (text_type)
 
         Example::
 

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1443,7 +1443,7 @@ class NetworkDriver(object):
 
     def get_firewall_policies(self):
         """
-        Returns a dictionary of dictionaries where the first key is an unique policy name and the
+        Returns a dictionary of lists of dictionaries where the first key is an unique policy name and the
         inner dictionary contains the following keys:
 
         * position (int)
@@ -1461,7 +1461,7 @@ class NetworkDriver(object):
         Example::
 
         {
-            'src_zone-to-dst_zone': {
+            'policy_name': [{
                 'position': 1,
                 'id': '230',
                 'enabled': True,
@@ -1473,7 +1473,7 @@ class NetworkDriver(object):
                 'src_zone': 'port2',
                 'dst_zone': 'port3',
                 'action': 'Permit'
-            }
+            }]
         }
         """
         raise NotImplementedError

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1446,7 +1446,7 @@ class NetworkDriver(object):
         Return a dictionary of configured Firewall policies
 
         Returns:
-            A dictionary of policies 
+            A dictionary of policies
             * name
                 * n amount of arguments
 
@@ -1475,4 +1475,4 @@ class NetworkDriver(object):
            }
         }
         """
-        raise NotImplementedError 
+        raise NotImplementedError

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1443,14 +1443,23 @@ class NetworkDriver(object):
 
     def get_firewall_policies(self):
         """
-        Return a dictionary of configured Firewall policies
+        Returns a dictionary of dictionaries where the first key is an unique policy name and the
+        inner dictionary contains the following keys:
 
-        Returns:
-            A dictionary of policies
-            * name
-                * n amount of arguments
+        * position (int)
+        * id (text_type)
+        * enabled (bool)
+        * schedule (text_type)
+        * log (text_type)
+        * l3_src (text_type)
+        * l3_dst (text_type)
+        * service (text_type)
+        * src_zone (text_type)
+        * dst_zone (text_type)
+        * action (text_type)        
 
-        Example:
+        Example::
+
         {
             'src_zone-to-dst_zone': {
                 'position': 1,

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1447,6 +1447,8 @@ class NetworkDriver(object):
         name and the inner dictionary contains the following keys:
 
         * position (int)
+        * packet_hits (int)
+        * byte_hits (int)
         * id (text_type)
         * enabled (bool)
         * schedule (text_type)
@@ -1463,6 +1465,8 @@ class NetworkDriver(object):
         {
             'policy_name': [{
                 'position': 1,
+                'packet_hits': 200,
+                'byte_hits': 83883,
                 'id': '230',
                 'enabled': True,
                 'schedule': 'Always',

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1454,23 +1454,23 @@ class NetworkDriver(object):
         {
             '1': {
                 'uuid': '9d747de8-dad4-51e5-7a7e-d078aa77140a',
-                'service': '"ALL"', 
-                'schedule': '"always"', 
-                'srcaddr': '"all"', 
-                'dstintf': '"any"', 
-                'srcintf': '"any"', 
-                'action': 'accept', 
+                'service': '"ALL"',
+                'schedule': '"always"',
+                'srcaddr': '"all"',
+                'dstintf': '"any"',
+                'srcintf': '"any"',
+                'action': 'accept',
                 'dstaddr': '"all"'
-            } 
+            }
             '2': {
                 'name': '"bla"',
                 'service': '"ALL"',
-                'schedule': '"always"', 
+                'schedule': '"always"',
                 'logtraffic': 'all',
-                'srcaddr': '"all"', 
-                'dstintf': '"port2"', 
-                'srcintf': '"port3"', 
-                'dstaddr': '"all"', 
+                'srcaddr': '"all"',
+                'dstintf': '"port2"',
+                'srcintf': '"port3"',
+                'dstaddr': '"all"',
                 'uuid': 'de597b64-aca8-51e6-5d00-b7874e6b72b8'
            }
         }

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -1443,8 +1443,8 @@ class NetworkDriver(object):
 
     def get_firewall_policies(self):
         """
-        Returns a dictionary of lists of dictionaries where the first key is an unique policy name and the
-        inner dictionary contains the following keys:
+        Returns a dictionary of lists of dictionaries where the first key is an unique policy 
+	name and the inner dictionary contains the following keys:
 
         * position (int)
         * id (text_type)

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -166,6 +166,14 @@ class TestGettersNetworkDriver(object):
 
         return correct_class and same_keys
 
+    def test_get_firewall_policies(self):
+        try:
+            policies = self.device.get_firewall_policies()
+        except NotImplementedError:
+            raise SkipTest()
+        result = len(policies["1"]) > 0
+        self.assertTrue(result)
+
     def test_is_alive(self):
         try:
             alive = self.device.is_alive()

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -171,7 +171,8 @@ class TestGettersNetworkDriver(object):
             policies = self.device.get_firewall_policies()
         except NotImplementedError:
             raise SkipTest()
-        result = len(policies) > 0
+        for policy_name, policy_details in policies.items():
+            result = result and self._test_model(models.firewall_policies, policy_details)
         self.assertTrue(result)
 
     def test_is_alive(self):

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -171,8 +171,12 @@ class TestGettersNetworkDriver(object):
             policies = self.device.get_firewall_policies()
         except NotImplementedError:
             raise SkipTest()
+
+        result = len(policies) > 0
+
         for policy_name, policy_details in policies.items():
             result = result and self._test_model(models.firewall_policies, policy_details)
+
         self.assertTrue(result)
 
     def test_is_alive(self):

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -171,7 +171,7 @@ class TestGettersNetworkDriver(object):
             policies = self.device.get_firewall_policies()
         except NotImplementedError:
             raise SkipTest()
-        result = len(policies["1"]) > 0
+        result = len(policies["any-to-any"]) > 0
         self.assertTrue(result)
 
     def test_is_alive(self):

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -171,7 +171,7 @@ class TestGettersNetworkDriver(object):
             policies = self.device.get_firewall_policies()
         except NotImplementedError:
             raise SkipTest()
-        result = len(policies["any-to-any"]) > 0
+        result = len(policies) > 0
         self.assertTrue(result)
 
     def test_is_alive(self):

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -175,7 +175,8 @@ class TestGettersNetworkDriver(object):
         result = len(policies) > 0
 
         for policy_name, policy_details in policies.items():
-            result = result and self._test_model(models.firewall_policies, policy_details)
+            for policy_term in policy_details:
+                result = result and self._test_model(models.firewall_policies, policy_term)
 
         self.assertTrue(result)
 

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -463,3 +463,15 @@ class BaseTestGetters(object):
                                       network_instance['interfaces'])
 
         return get_network_instances
+    
+    @wrap_test_cases
+    def test_get_firewall_policies(self, test_case):
+        """Test get_firewall_policies method."""
+        get_firewall_policies = self.device.get_firewall_policies()
+        assert len(get_firewall_policies) > 0
+        for policy in get_firewall_policies:
+            for item in policy:
+                assert helpers.test_model(models.item)
+        
+        return get_firewall_policies
+            

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -463,7 +463,7 @@ class BaseTestGetters(object):
                                       network_instance['interfaces'])
 
         return get_network_instances
-    
+
     @wrap_test_cases
     def test_get_firewall_policies(self, test_case):
         """Test get_firewall_policies method."""

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -469,9 +469,7 @@ class BaseTestGetters(object):
         """Test get_firewall_policies method."""
         get_firewall_policies = self.device.get_firewall_policies()
         assert len(get_firewall_policies) > 0
-        for policy in get_firewall_policies:
-            for item in policy:
-                assert helpers.test_model(models.item)
-        
+        for firewall_policies in get_firewall_policies:
+            assert helpers.test_model(models.firewall_policies)
+
         return get_firewall_policies
-            

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -470,6 +470,6 @@ class BaseTestGetters(object):
         get_firewall_policies = self.device.get_firewall_policies()
         assert len(get_firewall_policies) > 0
         for policy_name, policy_details in get_firewall_policies.items():
-            assert helpers.test_model(models.firewall_policies, policy_details)
-
+            for policy_term in policy_details:
+                assert helpers.test_model(models.firewall_policies, policy_term)
         return get_firewall_policies

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -469,7 +469,7 @@ class BaseTestGetters(object):
         """Test get_firewall_policies method."""
         get_firewall_policies = self.device.get_firewall_policies()
         assert len(get_firewall_policies) > 0
-        for firewall_policies in get_firewall_policies:
-            assert helpers.test_model(models.firewall_policies)
+        for policy_name, policy_details in get_firewall_policies.items():
+            assert helpers.test_model(models.firewall_policies, policy_details)
 
         return get_firewall_policies

--- a/napalm_base/test/models.py
+++ b/napalm_base/test/models.py
@@ -320,6 +320,8 @@ network_instance_interfaces = {
 
 firewall_policies = {
     'position': int,
+    'packet_hits': int,
+    'byte_hits': int,
     'id': text_type,
     'enabled': bool,
     'schedule': text_type,

--- a/napalm_base/test/models.py
+++ b/napalm_base/test/models.py
@@ -317,3 +317,17 @@ network_instance_state = {
 network_instance_interfaces = {
     'interface': dict,
 }
+
+firewall_policies = {
+    'position': int,
+    'id': text_type,
+    'enabled': bool,
+    'schedule': text_type,
+    'log': text_type,
+    'l3_src': text_type,
+    'l3_dst': text_type,
+    'service': text_type,
+    'src_zone': text_type,
+    'dst_zone': text_type,
+    'action': text_type
+}


### PR DESCRIPTION
It would be nice to have an output of all configured Firewall policies. In an easy and parseable way.

For this I would propose to use the method get_firewall_policies .

Output:
`>>> device.get_firewall_rules()
{'1': {'uuid': '9d747de8-dad4-51e5-7a7e-d078aa77140a', 'service': '"ALL"', 'schedule': '"always"', 'srcaddr': '"all"', 'dstintf': '"any"', 'srcintf': '"any"', 'action': 'accept', 'dstaddr': '"all"'}, '2': {'name': '"bla"', 'service': '"ALL"', 'schedule': '"always"', 'logtraffic': 'all', 'srcaddr': '"all"', 'dstintf': '"port2"', 'srcintf': '"port3"', 'dstaddr': '"all"', 'uuid': 'de597b64-aca8-51e6-5d00-b7874e6b72b8'}}`

I already implemented the feature for FortiOS:
https://github.com/napalm-automation/napalm-fortios/pull/22