### PR TITLE
Added a way of adding tests that don't require test cases and a test …

### DIFF
--- a/napalm_base/test/conftest.py
+++ b/napalm_base/test/conftest.py
@@ -31,19 +31,20 @@ def set_device_parameters(request):
 
 def pytest_generate_tests(metafunc, basefile):
     """Generate test cases dynamically."""
-    path = os.path.join(os.path.dirname(basefile), 'mocked_data', metafunc.function.__name__)
+    if metafunc.function.func_dict.get('build_test_cases', False):
+        path = os.path.join(os.path.dirname(basefile), 'mocked_data', metafunc.function.__name__)
 
-    if os.path.exists(path):
-        sub_folders = os.listdir(path)
-    else:
-        sub_folders = []
+        if os.path.exists(path):
+            sub_folders = os.listdir(path)
+        else:
+            sub_folders = []
 
-    test_cases = []
-    for test_case in sub_folders:
-        if os.path.isdir(os.path.join(path, test_case)):
-            test_cases.append(test_case)
+        test_cases = []
+        for test_case in sub_folders:
+            if os.path.isdir(os.path.join(path, test_case)):
+                test_cases.append(test_case)
 
-    if not test_cases:
-        test_cases.append("no_test_case_found")
+        if not test_cases:
+            test_cases.append("no_test_case_found")
 
-    metafunc.parametrize("test_case", test_cases)
+        metafunc.parametrize("test_case", test_cases)

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -10,12 +10,14 @@ try:
 except ImportError:
     from itertools import zip_longest
 
+import inspect
 import json
 import os
 
 import pytest
 from napalm_base.test import helpers
 from napalm_base.test import models
+from napalm_base import NetworkDriver
 
 # text_type is 'unicode' for py2 and 'str' for py3
 from napalm_base.utils.py23_compat import text_type
@@ -58,6 +60,8 @@ def dict_diff(prv, nxt):
 
 def wrap_test_cases(func):
     """Wrap test cases."""
+    func.func_dict['build_test_cases'] = True
+
     @functools.wraps(func)
     def wrapper(cls, test_case):
         for patched_attr in cls.device.patched_attrs:
@@ -107,6 +111,31 @@ def wrap_test_cases(func):
 
 class BaseTestGetters(object):
     """Base class for testing drivers."""
+
+    def test_method_signatures(self):
+        """Test that all methods have the same signature."""
+        cls = self.driver
+        attrs = [m for m in dir(cls)]
+        for attr in attrs:
+            func = getattr(cls, attr)
+            if attr.startswith('_') or not inspect.ismethod(func):
+                continue
+            orig = getattr(NetworkDriver, attr)
+
+            orig_spec = inspect.getargspec(orig)
+            func_spec = inspect.getargspec(func)
+            msg = "Method {} varies.\nNetworkDriver: {}\n{}: {}".format(attr, orig_spec,
+                                                                        cls.__name__, func_spec)
+            assert orig_spec == func_spec, msg
+
+        EXTRA_METHODS = ['__init__', ]
+        for method in EXTRA_METHODS:
+            if not method.startswith('_'):
+                orig_spec = inspect.getargspec(getattr(NetworkDriver, method))
+                func_spec = inspect.getargspec(getattr(cls, method))
+                msg = "Method {} varies.\nNetworkDriver: {}\n{}: {}".format(attr, orig_spec,
+                                                                            cls.__name__, func_spec)
+                assert orig_spec == func_spec, msg
 
     @wrap_test_cases
     def test_is_alive(self, test_case):

--- a/napalm_base/test/getters.py
+++ b/napalm_base/test/getters.py
@@ -114,6 +114,7 @@ class BaseTestGetters(object):
 
     def test_method_signatures(self):
         """Test that all methods have the same signature."""
+        errors = {}
         cls = self.driver
         attrs = [m for m in dir(cls)]
         for attr in attrs:
@@ -124,18 +125,18 @@ class BaseTestGetters(object):
 
             orig_spec = inspect.getargspec(orig)
             func_spec = inspect.getargspec(func)
-            msg = "Method {} varies.\nNetworkDriver: {}\n{}: {}".format(attr, orig_spec,
-                                                                        cls.__name__, func_spec)
-            assert orig_spec == func_spec, msg
+            if orig_spec != func_spec:
+                errors[attr] = (orig_spec, func_spec)
 
         EXTRA_METHODS = ['__init__', ]
         for method in EXTRA_METHODS:
             if not method.startswith('_'):
                 orig_spec = inspect.getargspec(getattr(NetworkDriver, method))
                 func_spec = inspect.getargspec(getattr(cls, method))
-                msg = "Method {} varies.\nNetworkDriver: {}\n{}: {}".format(attr, orig_spec,
-                                                                            cls.__name__, func_spec)
-                assert orig_spec == func_spec, msg
+                if orig_spec != func_spec:
+                    errors[attr] = (orig_spec, func_spec)
+
+        assert not errors, "Some method vary. \n{}".format(errors)
 
     @wrap_test_cases
     def test_is_alive(self, test_case):


### PR DESCRIPTION
This PR has two purposes:

1. Distinguish between methods that require to build cases and methods that don't.
2. Add a test to verify that all public methods for a given driver have the same signature than the base driver.

Thanks to this I found this that for the EOS driver we have some discrepancies:

```
E       AssertionError: Some method vary.
E       {'ping': (ArgSpec(args=['self', 'destination', 'source', 'ttl', 'timeout', 'size', 'count'], varargs=None, keywords=None, defaults=(u'', 0, 0, 0, 0)), ArgSpec(args=['self', 'destination', 'source', 'ttl', 'timeout', 'size', 'count'], varargs=None, keywords=None, defaults=(u'', 255, 2, 100, 5))), 'cli': (ArgSpec(args=['self'], varargs='commands', keywords=None, defaults=None), ArgSpec(args=['self', 'commands'], varargs=None, keywords=None, defaults=(None,)))}
```