### PR TITLE
add support napalm conf file

### DIFF
--- a/napalm_base/__init__.py
+++ b/napalm_base/__init__.py
@@ -55,8 +55,10 @@ __all__ = [
     'network_device'
 ]
 
+
 LIB_PATH_ENV_VAR = 'NAPALM_CONF'
 LIB_PATH_DEFAULT = '~/napalm.conf'
+
 
 def get_network_driver(module_name):
     """
@@ -118,6 +120,7 @@ def get_network_driver(module_name):
     raise ModuleImportError(
         'No class inheriting "napalm_base.base.NetworkDriver" found in "{install_name}".'
         .format(install_name=module_install_name))
+
 
 def network_device(named_device, filename=None):
     """
@@ -196,6 +199,7 @@ def network_device(named_device, filename=None):
 
                 """
 
+
 def _get_device(driver, device_kwargs):
 
     core_keys = ['hostname', 'username', 'password', 'timeout']
@@ -234,4 +238,3 @@ def _get_config_from_file(filename=None):
     config.read(filename)
 
     return config, filename
-

--- a/napalm_base/__init__.py
+++ b/napalm_base/__init__.py
@@ -19,10 +19,16 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 # Python std lib
+import os
 import sys
 import inspect
 import importlib
 import pkg_resources
+
+try:
+    from configparser import ConfigParser as SafeConfigParser
+except ImportError:
+    from ConfigParser import SafeConfigParser
 
 # Verify Python Version that is running
 try:
@@ -45,9 +51,12 @@ except pkg_resources.DistributionNotFound:
 
 __all__ = [
     'get_network_driver',  # export the function
-    'NetworkDriver'  # also export the base class
+    'NetworkDriver',  # also export the base class
+    'network_device'
 ]
 
+LIB_PATH_ENV_VAR = 'NAPALM_CONF'
+LIB_PATH_DEFAULT = '~/napalm.conf'
 
 def get_network_driver(module_name):
     """
@@ -109,3 +118,120 @@ def get_network_driver(module_name):
     raise ModuleImportError(
         'No class inheriting "napalm_base.base.NetworkDriver" found in "{install_name}".'
         .format(install_name=module_install_name))
+
+def network_device(named_device, filename=None):
+    """
+
+    Instantiate and return an instance of a NetworkDriver
+    If no filename is given the environment variable NAPALM_CONF is checked
+    for a path, and finally then ~/napalm.conf is used.
+
+    Arguments:
+        named_device (string): Name of the device as listed in the napalm configuration file.
+        filename (string): (Optional) Path to napalm configuration file that includes
+            the ``named_device`` argument as section header.
+    Raises:
+        DeviceNameNotFoundError: if the named_device is not found in the
+            napalm configuration file.
+        ConfFileNotFoundError: if no napalm configuration file can be found.
+
+    Example (napalm conf file)::
+
+    .. code-block:: python
+        [nxos:n9k1]
+        username: ntc
+        password: pwd123
+
+        [nxos:n9k2]
+        username: ntc
+        password: pwd123
+
+        [ios:csr1]
+        hostname: 10.1.100.10
+        username: ntc
+        password: ntc123
+
+        [eos:eos-spine1]
+        hostname: 10.1.100.11
+        username: ntc
+        password: ntc123
+
+    Example::
+
+
+    .. code-block:: python
+
+        >>> from napalm import network_device
+        >>> device = network_device('csr1')
+        >>> device
+        <napalm_ios.ios.IOSDriver object at 0x7f8e91392210>
+        >>>
+
+    """
+    config, filename = _get_config_from_file(filename=filename)
+    sections = config.sections()
+
+    """
+    TODO: NEED TO IMPLEMENT ConfFileNotFoundError
+    if not sections:
+        raise ConfFileNotFoundError(filename)
+    """
+
+    for section in sections:
+        if ':' in section:
+            device_type, conn_name = section.split(':')
+            if named_device == conn_name:
+                device_kwargs = dict(config.items(section))
+                if 'hostname' not in device_kwargs:
+                    device_kwargs['hostname'] = named_device
+
+                driver = get_network_driver(device_type)
+                device = _get_device(driver, device_kwargs)
+                device.open()
+                return device
+
+                """
+                TODO: NEED TO IMPLEMENT
+                raise DeviceNotFoundError(name, filename)
+
+                """
+
+def _get_device(driver, device_kwargs):
+
+    core_keys = ['hostname', 'username', 'password', 'timeout']
+    optional_args = dict((k, v) for k, v in device_kwargs.items()
+                         if v is not None and k not in core_keys)
+
+    hostname = device_kwargs['hostname']
+    un = device_kwargs['username']
+    pwd = device_kwargs['password']
+
+    if device_kwargs.get('timeout'):
+        timeout = device_kwargs.get('timeout')
+        if optional_args:
+            device = driver(hostname, un, pwd, timeout=timeout,
+                            optional_args=optional_args)
+        else:
+            device = driver(hostname, un, pwd, timeout=timeout)
+    else:
+        if optional_args:
+            device = driver(hostname, un, pwd,
+                            optional_args=optional_args)
+        else:
+            device = driver(hostname, un, pwd)
+    return device
+
+
+def _get_config_from_file(filename=None):
+
+    if filename is None:
+        if LIB_PATH_ENV_VAR in os.environ:
+            filename = os.path.expanduser(os.environ[LIB_PATH_ENV_VAR])
+        else:
+            filename = os.path.expanduser(LIB_PATH_DEFAULT)
+
+    config = SafeConfigParser()
+    config.read(filename)
+
+    return config, filename
+

--- a/napalm_base/__init__.py
+++ b/napalm_base/__init__.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 # Python std lib
-import os
 import sys
 import inspect
 import importlib
@@ -46,7 +45,7 @@ except pkg_resources.DistributionNotFound:
 
 __all__ = [
     'get_network_driver',  # export the function
-    'NetworkDriver',  # also export the base class
+    'NetworkDriver'  # also export the base class
 ]
 
 
@@ -110,4 +109,3 @@ def get_network_driver(module_name):
     raise ModuleImportError(
         'No class inheriting "napalm_base.base.NetworkDriver" found in "{install_name}".'
         .format(install_name=module_install_name))
-

--- a/napalm_base/inventory.py
+++ b/napalm_base/inventory.py
@@ -1,0 +1,186 @@
+
+import os
+import json
+import yaml
+import collections
+
+
+from napalm import get_network_driver
+
+
+class Inventory(object):
+
+    def __init__(self, filename=None):
+        self.LIB_PATH_DEFAULT = '~/napalm.yml'
+        self.LIB_PATH_ENV_VAR = 'NAPALM_CONF'
+        self.filename = self._get_filename(filename)
+        self._raw_inventory = self._generate_inventory()
+        self.inventory = self.get_inventory()
+
+    def get_groups(self):
+        return self.inventory.keys()
+
+    def _get_group(self, group_name):
+        devices_in_group = self.inventory.get(group_name)
+        if devices_in_group:
+            return devices_in_group.keys()
+        return []
+
+    def get_devices(self, group_name='all'):
+        device_list = []
+        if group_name == 'all':
+            for group_name, devices in self.inventory.items():
+                for device_name, attrs in devices.items():
+                    device_list.append(device_name)
+        else:
+            device_list = self._get_group(group_name)
+
+        return device_list
+
+    def get_device(self, device):
+        device_kwargs = {}
+
+        for group_name, devices in self.inventory.items():
+            for device_name, attrs in devices.items():
+                if device == device_name:
+                    device_kwargs = attrs
+        dev_os = device_kwargs.get('dev_os')
+        driver = get_network_driver(dev_os)
+        device = self._get_device(driver, device_kwargs)
+        return device
+
+    def get_group(self, group_name):
+        devices = self.get_devices(group_name=group_name)
+        napalm_devices = []
+        for device in devices:
+            napalm_devices.append(self.get_device(device))
+        return napalm_devices
+
+    def _get_device(self, driver, device_kwargs):
+
+        hostname = device_kwargs['hostname']
+        un = device_kwargs['username']
+        pwd = device_kwargs['password']
+        optional_args = device_kwargs.get('optional_args')
+
+        if device_kwargs.get('timeout'):
+            timeout = device_kwargs.get('timeout')
+            if optional_args:
+                device = driver(hostname, un, pwd, timeout=timeout,
+                                optional_args=optional_args)
+            else:
+                device = driver(hostname, un, pwd, timeout=timeout)
+        else:
+            if optional_args:
+                device = driver(hostname, un, pwd,
+                                optional_args=optional_args)
+            else:
+                device = driver(hostname, un, pwd)
+        return device
+
+    def _ensure_hostname(self, inventory, device):
+        """Ensure hostname key is in device kwargs
+        If hostname key not suppplied, device name is supplied
+        back in hostname key.
+        """
+
+        hostname = inventory.get('hostname')
+        if not hostname:
+            inventory['hostname'] = device
+        return inventory
+
+    def _sort_dict(self, unsorted_dict):
+        return collections.OrderedDict(sorted(unsorted_dict.items()))
+
+    def _sort_inventory(self, unsorted_inventory):
+        sorted_inventory = {}
+        for group_name, devices in self._raw_inventory.items():
+            sorted_inventory[group_name] = {}
+            for device_name, attrs in devices.items():
+                sorted_inventory[group_name][device_name] = self._sort_dict(attrs)
+            sorted_inventory[group_name] = self._sort_dict(sorted_inventory[group_name])
+        sorted_inventory = self._sort_dict(sorted_inventory)
+        return sorted_inventory
+
+    def _get_filename(self, filename):
+        """Get filename for NAPALM conf file
+
+        Priority:
+            1. Use filename param in constructor
+            2. NAPALM ENV Variable, i.e. LIB_PATH_ENV_VAR
+            3. Home directory
+        """
+
+        if filename is None:
+            if self.LIB_PATH_ENV_VAR in os.environ:
+                filename = os.path.expanduser(os.environ[self.LIB_PATH_ENV_VAR])
+            else:
+                filename = os.path.expanduser(self.LIB_PATH_DEFAULT)
+        elif '~' in filename:
+            filename = os.path.expanduser(filename)
+        return filename
+
+    def get_inventory(self):
+        sorted_inventory = self._sort_inventory(self._raw_inventory)
+        return sorted_inventory
+
+    def _generate_inventory(self):
+        inventory_data = yaml.load(open(self.filename))
+
+        groups = inventory_data.get('groups')
+        default_vars = {}
+        if groups:
+            if groups.get('default'):
+                default_vars = groups.get('default')
+            inventory_data.pop('groups')
+        expanded_inventory = {}
+        for device, attributes in inventory_data.items():
+            groups_for_device = attributes.get('groups') or 'default'
+            if isinstance(groups_for_device, str):
+                groups_for_device = [groups_for_device]
+            for group, group_params in groups.items():
+                if group in groups_for_device and group != 'default':
+                    if not expanded_inventory.get(group):
+                        expanded_inventory[group] = {}
+                    expanded_inventory[group][device] = {}
+                    group_vars = groups.get(group)
+
+                    # apply default variables first (default group)
+                    if default_vars:
+                        expanded_inventory[group][device].update(default_vars)
+                    # if group vars supplied, applies them
+                    if group_vars:
+                        expanded_inventory[group][device].update(group_vars)
+                    # finally applies highest priority variables, i.e. device specific vars
+                    expanded_inventory[group][device].update(attributes)
+                    # removing groups key to more easily pass to napalm kwargs
+                    if 'groups' in expanded_inventory[group][device]:
+                        expanded_inventory[group][device].pop('groups')
+                    expanded_inventory[group][device] = self._ensure_hostname(expanded_inventory[group][device], device)
+        return expanded_inventory
+
+
+if __name__ == "__main__":
+
+    inventory = Inventory('~/napalm2.yml')  # Inventory() would use default settings
+    inv = inventory.get_inventory()
+    # print json.dumps(inv, indent=4)
+
+    # list of group names
+    print inventory.get_groups()
+
+    # list of all devices
+    print inventory.get_devices()
+
+    # optionally, pass group name- return list of devices in group
+    print inventory.get_devices('dc_edge')
+
+    # return instantiated driver device object for provided device
+    print inventory.get_device('csr1')
+    print inventory.get_device('eos-spine1')
+
+    # return list of instantiated driver device objects for provided group
+    cisco_devices = inventory.get_group('cisco_ios')
+    print cisco_devices
+    dc_edge_devices = inventory.get_group('dc_edge')
+    print dc_edge_devices


### PR DESCRIPTION
This PR is to simplify the creation of NAPALM device objects using a NAPALM configuration file.  Doesn't change the way anything works - just offers this as an option.

The current approach:

```
from napalm import get_network_driver
driver = get_network_driver('ios')
device = driver('csr1', 'username', 'password')

```

With this PR, you will also be able to do:

```
from napalm import network_device
device = network_device('csr1')
```

Requires this: https://github.com/napalm-automation/napalm/pull/328


`network_device` is also opening the connection, i.e. calling the `open` method.  The conf file is also nice as it hides (abstracts) details such as username, password, and optional args per device.

Currently, any parameter that is NOT `username`, `password`, `hostname`, or `timeout` is considered an *optional_arg* and will be passed to the NetworkDriver as such.


This is a sample Napalm configuration file:

```
[nxos:n9k1]
username: ntc
password: ntc123

[nxos:n9k2]
username: ntc
password: ntc123

[ios:csr1]
hostname: 1.1.1.1
username: ntc
password: ntc123

[eos:eos-spine1]
hostname: 2.2.2.2
username: ntc
password: ntc123


```

The structure is:  `[<napalm_os_type>:<device_name>]` where `napalm_os_type` should match a given driver while `device_name` can either be a IP/FQDN or just a device reference.  If the `hostname` key is not given for a device, the `device_name` is used as the `hostname` in the NetworkDriver.

There is currently no support for groups and defaults. Each device must be defined.  Not difficult if you template out this file.

The file can be specified one of three ways and in this order:
- use the `filename` parameter when instantiating a new device object with this new method called `network_device`
- use the NAPALM_CONF environment variable
- use `~/napalm.conf` (in your home directory)

 
TODO:
  - Still need to add custom exceptions
  - Wanted feedback first if it makes sense
  - Any guidance on tests for this would be helpful too


