### PR TITLE
Adding CLI tool for validate

### DIFF
--- a/napalm_base/clitools/cl_napalm_configure.py
+++ b/napalm_base/clitools/cl_napalm_configure.py
@@ -52,7 +52,7 @@ def run(vendor, hostname, user, password, strategy, optional_args, config_file, 
 
 
 def main():
-    args = build_help()
+    args = build_help(configure=True)
     configure_logging(logger, args.debug)
 
     print(run(args.vendor, args.hostname, args.user, args.password, args.strategy,

--- a/napalm_base/clitools/cl_napalm_validate.py
+++ b/napalm_base/clitools/cl_napalm_validate.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+'''
+NAPALM CLI Tools: validate
+===========================
+
+Validating deployments from the shell.
+'''
+
+# Python3 support
+from __future__ import print_function
+from __future__ import unicode_literals
+
+# import helpers
+from napalm_base import get_network_driver
+from napalm_base.clitools.helpers import build_help
+from napalm_base.clitools.helpers import configure_logging
+from napalm_base.clitools.helpers import parse_optional_args
+
+# stdlib
+import sys
+import json
+import logging
+logger = logging.getLogger('cl_napalm_validate.py')
+
+
+def main():
+    args = build_help(validate=True)
+    configure_logging(logger, args.debug)
+
+    logger.debug('Getting driver for OS "{driver}"'.format(driver=args.vendor))
+    driver = get_network_driver(args.vendor)
+
+    optional_args = parse_optional_args(args.optional_args)
+    logger.debug('Connecting to device "{}" with user "{}" and optional_args={}'.format(
+                 args.hostname, args.user, optional_args))
+
+    with driver(args.hostname, args.user, args.password, optional_args=optional_args) as device:
+        logger.debug('Generating compliance report')
+        print(json.dumps(device.compliance_report(args.validation_file), indent=4))
+        logger.debug('Closing session')
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/napalm_base/clitools/helpers.py
+++ b/napalm_base/clitools/helpers.py
@@ -16,7 +16,7 @@ import getpass
 import argparse
 
 
-def build_help(connect_test=False):
+def build_help(connect_test=False, validate=False, configure=False):
     parser = argparse.ArgumentParser(
         description='Command line tool to handle configuration on devices using NAPALM.'
                     'The script will print the diff on the screen',
@@ -60,7 +60,7 @@ def build_help(connect_test=False):
         action='store_true',
         help='Enables debug mode; more verbosity.'
     )
-    if not connect_test:
+    if configure:
         parser.add_argument(
             '--strategy', '-s',
             dest='strategy',
@@ -80,6 +80,13 @@ def build_help(connect_test=False):
             action='store_true',
             default=None,
             help='Only returns diff, it does not deploy the configuration.',
+        )
+    elif validate:
+        parser.add_argument(
+            '--validation_file', '-f',
+            dest='validation_file',
+            action='store',
+            help='Validation file containing resources derised states'
         )
     args = parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
     entry_points={
         'console_scripts': [
             'cl_napalm_configure=napalm_base.clitools.cl_napalm_configure:main',
-            'cl_napalm_test=napalm_base.clitools.cl_napalm_test:main'
+            'cl_napalm_test=napalm_base.clitools.cl_napalm_test:main',
+            'cl_napalm_validate=napalm_base.clitools.cl_napalm_validate:main'
         ],
     }
 )


### PR DESCRIPTION
Sample usage:

```
---
get_facts:
  os_version: 7.0(3)I2(2d)
  interface_list:
    - Vlan5
    - Vlan100
  hostname: n9k1

get_lldp_neighbors:
  Eth1/1:
    - hostname: n9k2.ntc.com
      port: Ethernet1/1

get_bgp_neighbors:
  default:
    router_id: 192.0.2.2
    peers:
      192.0.2.2:
        address_family:
          ipv4:
            sent_prefixes: 5
          ipv6:
            sent_prefixes: 2
```

```
$ cl_napalm_validate --user test --vendor nxos --validation_file test.yml n9k1 --debug
Enter password: 
2016-12-18 12:50:09,425 - cl_napalm_validate.py - DEBUG - Getting driver for OS "nxos"
2016-12-18 12:50:10,288 - cl_napalm_validate.py - DEBUG - Connecting to device "n9k1" with user "test" and optional_args={}
2016-12-18 12:50:10,734 - cl_napalm_validate.py - DEBUG - Generating compliance report
{
    "get_facts": {
        "extra": [], 
        "complies": false, 
        "present": {
            "os_version": {
                "complies": false, 
                "actual_value": "6.1(2)I3(1)", 
                "nested": false
            }, 
            "interface_list": {
                "complies": false, 
                "actual_value": [
                    "mgmt0", 
                    "Ethernet1/1", 
                    "Ethernet1/2", 
                    "Ethernet1/3", 
                    "Ethernet1/4", 
                    "Ethernet1/5", 
                    "Ethernet1/6", 
                    "Ethernet1/7", 
                    "Ethernet1/8", 
                    "Ethernet1/9", 
                    "Ethernet1/10", 
                    "Ethernet1/11", 
                    "Ethernet1/12", 
                    "Ethernet1/13", 
                    "Ethernet1/14", 
                    "Ethernet1/15", 
                    "Ethernet1/16", 
                    "Ethernet1/17", 
                    "Ethernet1/18", 
                    "Ethernet1/19", 
                    "Ethernet1/20", 
                    "Ethernet1/21", 
                    "Ethernet1/22", 
                    "Ethernet1/23", 
                    "Ethernet1/24", 
                    "Ethernet1/25", 
                    "Ethernet1/26", 
                    "Ethernet1/27", 
                    "Ethernet1/28", 
                    "Ethernet1/29", 
                    "Ethernet1/30", 
                    "Ethernet1/31", 
                    "Ethernet1/32", 
                    "Ethernet1/33", 
                    "Ethernet1/34", 
                    "Ethernet1/35", 
                    "Ethernet1/36", 
                    "Ethernet1/37", 
                    "Ethernet1/38", 
                    "Ethernet1/39", 
                    "Ethernet1/40", 
                    "Ethernet1/41", 
                    "Ethernet1/42", 
                    "Ethernet1/43", 
                    "Ethernet1/44", 
                    "Ethernet1/45", 
                    "Ethernet1/46", 
                    "Ethernet1/47", 
                    "Ethernet1/48", 
                    "Ethernet2/1", 
                    "Ethernet2/2", 
                    "Ethernet2/3", 
                    "Ethernet2/4", 
                    "Ethernet2/5", 
                    "Ethernet2/6", 
                    "Ethernet2/7", 
                    "Ethernet2/8", 
                    "Ethernet2/9", 
                    "Ethernet2/10", 
                    "Ethernet2/11", 
                    "Ethernet2/12", 
                    "port-channel52", 
                    "loopback10", 
                    "loopback100", 
                    "loopback101", 
                    "loopback102", 
                    "loopback103", 
                    "Vlan1"
                ], 
                "nested": false
            }, 
            "hostname": {
                "complies": true, 
                "nested": false
            }
        }, 
        "missing": []
    }, 
    "complies": false, 
    "get_lldp_neighbors": {
        "extra": [], 
        "complies": true, 
        "present": {
            "Eth1/1": {
                "complies": true, 
                "nested": false
            }
        }, 
        "missing": []
    }, 
    "get_bgp_neighbors": {
        "extra": [], 
        "complies": false, 
        "present": {}, 
        "missing": [
            "default"
        ]
    }
}
2016-12-18 12:50:14,368 - cl_napalm_validate.py - DEBUG - Closing session
```