### PR TITLE
Cl bugfix

### DIFF
--- a/napalm_base/clitools/cl_napalm_test.py
+++ b/napalm_base/clitools/cl_napalm_test.py
@@ -6,6 +6,8 @@ NAPALM CLI Tools: test connectivity
 Module to test connectivity with the network device through NAPALM.
 '''
 from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 # import helpers
 from napalm_base import get_network_driver

--- a/napalm_base/clitools/cl_napalm_test.py
+++ b/napalm_base/clitools/cl_napalm_test.py
@@ -6,8 +6,6 @@ NAPALM CLI Tools: test connectivity
 Module to test connectivity with the network device through NAPALM.
 '''
 from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 
 # import helpers
 from napalm_base import get_network_driver
@@ -18,7 +16,7 @@ from napalm_base.clitools.helpers import parse_optional_args
 # stdlib
 import sys
 import logging
-logger = logging.getLogger(__file__)
+logger = logging.getLogger('cl_napalm_test.py')
 
 
 def main():
@@ -30,7 +28,7 @@ def main():
 
     optional_args = parse_optional_args(args.optional_args)
     logger.debug('Connecting to device "{}" with user "{}" and optional_args={}'.format(
-                 device=args.hostname, user=args.user, optional_args=optional_args))
+                 args.hostname, args.user, optional_args))
 
     with driver(args.hostname,
                 args.user,

--- a/napalm_base/clitools/cl_napalm_test.py
+++ b/napalm_base/clitools/cl_napalm_test.py
@@ -36,7 +36,7 @@ def main():
                 args.user,
                 args.password,
                 optional_args=optional_args) as device:
-        logger.debug('Successfully connected to the device: {}'.format(device))
+        logger.debug('Successfully connected to the device: {}'.format(args.hostname))
         print('Successfully connected to the device')
     sys.exit(0)
 

--- a/napalm_base/clitools/cl_napalm_test.py
+++ b/napalm_base/clitools/cl_napalm_test.py
@@ -36,7 +36,7 @@ def main():
                 args.user,
                 args.password,
                 optional_args=optional_args) as device:
-        logger.debug('Successfully connected to the device: {}'.format(args.hostname))
+        logger.debug('Successfully connected to the device: {}'.format(device.hostname))
         print('Successfully connected to the device')
     sys.exit(0)
 


### PR DESCRIPTION
Right now running the CLI tool for test results in this error:

```
$ cl_napalm_test --user test --vendor nxos  n9k1 --debug
Enter password:
2016-12-18 13:12:27,395 - /usr/local/lib/python2.7/dist-packages/napalm_base/clitools/cl_napalm_test.pyc - DEBUG - Getting driver for OS "nxos"
Traceback (most recent call last):
  File "/usr/local/bin/cl_napalm_test", line 11, in <module>
    load_entry_point('napalm-base==0.21.0', 'console_scripts', 'cl_napalm_test')()
  File "/usr/local/lib/python2.7/dist-packages/napalm_base/clitools/cl_napalm_test.py", line 33, in main
    device=args.hostname, user=args.user, optional_args=optional_args))
IndexError: tuple index out of range
```

This fix will make it work as expected and it'll also make it cleaner:

```
$ cl_napalm_test --user test --vendor nxos n9k1 --debug
Enter password: 
2016-12-18 13:23:49,101 - cl_napalm_test.py - DEBUG - Getting driver for OS "nxos"
2016-12-18 13:23:50,392 - cl_napalm_test.py - DEBUG - Connecting to device "n9k1" with user "test" and optional_args={}
2016-12-18 13:23:50,807 - cl_napalm_test.py - DEBUG - Successfully connected to the device: n9k1
Successfully connected to the device
```