### PR TITLE
Added reference to '_' as bgp group name

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -471,7 +471,7 @@ class NetworkDriver(object):
         :param neighbor: Returns the configuration of a specific BGP neighbor.
 
         Main dictionary keys represent the group name and the values represent a dictionary having
-        the following keys:
+        the keys below. Neighbors which aren't members of a group will be stored in a key named "_":
             * type (string)
             * description (string)
             * apply_groups (string list)


### PR DESCRIPTION
Adding a reference to using a "_" key for bgp neighbors not a member of any group.

As per request in: https://github.com/napalm-automation/napalm-iosxr/pull/96
