### PR TITLE
Added special keyword _name to override name in the report

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -49,7 +49,7 @@ class NetworkDriver(object):
     def __enter__(self):
         try:
             self.open()
-        except:
+        except:  # noqa
             exc_info = sys.exc_info()
             self.__raise_clean_exception(exc_info[0], exc_info[1], exc_info[2])
         return self

--- a/napalm_base/helpers.py
+++ b/napalm_base/helpers.py
@@ -177,7 +177,7 @@ def convert(to, who, default=u''):
         return default
     try:
         return to(who)
-    except:
+    except:  # noqa
         return default
 
 

--- a/napalm_base/validate.py
+++ b/napalm_base/validate.py
@@ -136,12 +136,14 @@ def compliance_report(cls, validation_file=None):
             # TBD
             pass
         else:
+            key = expected_results.pop("_name", "") or getter
+
             try:
                 kwargs = expected_results.pop('_kwargs', {})
                 actual_results = getattr(cls, getter)(**kwargs)
-                report[getter] = _compare_getter(expected_results, actual_results)
+                report[key] = _compare_getter(expected_results, actual_results)
             except NotImplementedError:
-                report[getter] = {"skipped": True, "reason": "NotImplemented"}
+                report[key] = {"skipped": True, "reason": "NotImplemented"}
 
     complies = all([e.get("complies", True) for e in report.values()])
     report["skipped"] = [k for k, v in report.items() if v.get("skipped", False)]

--- a/test/unit/validate/mocked_data/strict_pass_skip/report.yml
+++ b/test/unit/validate/mocked_data/strict_pass_skip/report.yml
@@ -5,7 +5,7 @@ method_not_implemented:
     skipped: true
 skipped:
     - method_not_implemented
-get_bgp_neighbors:
+check_bgp_neighbors_have_prefixes:
   complies: true
   extra: []
   missing: []

--- a/test/unit/validate/mocked_data/strict_pass_skip/validate.yml
+++ b/test/unit/validate/mocked_data/strict_pass_skip/validate.yml
@@ -12,6 +12,7 @@ method_not_implemented:
     something: asd
 
 get_bgp_neighbors:
+  _name: "check_bgp_neighbors_have_prefixes"
   default:
     router_id: 192.0.2.2
     peers:


### PR DESCRIPTION
Fixes #180

This adds a special keyword `_name` you can add to a getter to override the name in the report. Useful for being descriptive or for getters that accept arguments and can actually be used more than once in the same report.