### PR TITLE
Added commit confirm functionality

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -166,9 +166,17 @@ class NetworkDriver(object):
         """
         raise NotImplementedError
 
-    def commit_config(self):
+    def commit_config(self, revert_in=0):
         """
         Commits the changes requested by the method load_replace_candidate or load_merge_candidate.
+
+        :param revert_in: Number of seconds until rollback. Don't revert if 0.
+        """
+        raise NotImplementedError
+
+    def commit_confirm(self):
+        """
+        Confirm pending commit.
         """
         raise NotImplementedError
 

--- a/napalm_base/test/base.py
+++ b/napalm_base/test/base.py
@@ -59,6 +59,23 @@ class TestConfigNetworkDriver(object):
 
         self.assertEqual(len(diff), 0)
 
+    def test_replacing_and_committing_config_with_confirm(self):
+        try:
+            self.device.load_replace_candidate(filename='%s/new_good.conf' % self.vendor)
+            self.device.commit_config(revert_in=60)
+            self.device.commit_confirm()
+        except NotImplementedError:
+            raise SkipTest()
+
+        # The diff should be empty as the configuration has been committed already
+        diff = self.device.compare_config()
+
+        # Reverting changes
+        self.device.load_replace_candidate(filename='%s/initial.conf' % self.vendor)
+        self.device.commit_config()
+
+        self.assertEqual(len(diff), 0)
+
     def test_replacing_config_with_typo(self):
         result = False
         try:


### PR DESCRIPTION
Commit confirm functionality added to napalm base. It introduces new optional
argument in commit_config method and new method commit_confirm for
confirmation pending commit. It was briefly discussed under [napalm-junos#126](https://github.com/napalm-automation/napalm-junos/issues/126)