### PR TITLE
Adding check to __del__ to ignore exception if socket was already closed

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -65,7 +65,12 @@ class NetworkDriver(object):
         We need to make sure the connection is closed properly and the configuration DB
         is released (unlocked).
         """
-        self.close()
+        try:
+            self.close()
+        except OSError as e:
+            # Ignore if socket was already closed
+            if 'is closed' in str(e):
+                pass
 
     @staticmethod
     def __raise_clean_exception(exc_type, exc_value, exc_traceback):


### PR DESCRIPTION
Otherwise, an `OSError` exception is thrown during garbage collection when the session was already closed.