### PR TITLE
Add numeric compare for validation

### DIFF
--- a/napalm_base/validate.py
+++ b/napalm_base/validate.py
@@ -121,7 +121,10 @@ def _compare_getter(src, dst):
         return _compare_getter_dict(src, dst, mode)
     else:
         if isinstance(src, py23_compat.string_types):
-            m = re.search(src, py23_compat.text_type(dst))
+            if (src.startswith('<') or src.startswith('>') or src.startswith('=')):
+                m = compare_numeric(src, dst)
+            else:
+                m = re.search(src, py23_compat.text_type(dst))
             return m is not None
         elif(type(src) == type(dst) == list):
             pairs = zip(src, dst)
@@ -132,6 +135,12 @@ def _compare_getter(src, dst):
         else:
             return src == dst
 
+def compare_numeric(src_num, dst_num):
+    """Compare numerical values. You can use '<%f','>%f'and'=%f'."""
+    complies = eval(dst_num+src_num)
+    if isinstance(complies, bool):
+        return False
+    return complies
 
 def empty_tree(input_list):
     """Recursively iterate through values in nested lists."""

--- a/napalm_base/validate.py
+++ b/napalm_base/validate.py
@@ -122,10 +122,11 @@ def _compare_getter(src, dst):
     else:
         if isinstance(src, py23_compat.string_types):
             if src.startswith('<') or src.startswith('>'):
-                m = compare_numeric(src, dst)
+                cmp_result = compare_numeric(src, dst)
+                return cmp_result
             else:
                 m = re.search(src, py23_compat.text_type(dst))
-            return m is not None
+                return m is not None
         elif(type(src) == type(dst) == list):
             pairs = zip(src, dst)
             diff_lists = [[(k, x[k], y[k])

--- a/napalm_base/validate.py
+++ b/napalm_base/validate.py
@@ -121,7 +121,7 @@ def _compare_getter(src, dst):
         return _compare_getter_dict(src, dst, mode)
     else:
         if isinstance(src, py23_compat.string_types):
-            if (src.startswith('<') or src.startswith('>') or src.startswith('=')):
+            if src.startswith('<') or src.startswith('>'):
                 m = compare_numeric(src, dst)
             else:
                 m = re.search(src, py23_compat.text_type(dst))
@@ -136,9 +136,9 @@ def _compare_getter(src, dst):
             return src == dst
 
 def compare_numeric(src_num, dst_num):
-    """Compare numerical values. You can use '<%f','>%f'and'=%f'."""
-    complies = eval(dst_num+src_num)
-    if isinstance(complies, bool):
+    """Compare numerical values. You can use '<%d','>%d'."""
+    complies = eval(str(dst_num)+src_num)
+    if not isinstance(complies, bool):
         return False
     return complies
 

--- a/napalm_base/validate.py
+++ b/napalm_base/validate.py
@@ -136,12 +136,14 @@ def _compare_getter(src, dst):
         else:
             return src == dst
 
+
 def compare_numeric(src_num, dst_num):
     """Compare numerical values. You can use '<%d','>%d'."""
     complies = eval(str(dst_num)+src_num)
     if not isinstance(complies, bool):
         return False
     return complies
+
 
 def empty_tree(input_list):
     """Recursively iterate through values in nested lists."""

--- a/test/unit/validate/mocked_data/non_strict_fail/get_environment.json
+++ b/test/unit/validate/mocked_data/non_strict_fail/get_environment.json
@@ -1,13 +1,13 @@
 {
     "cpu": {
         "0/RP0/CPU0": {
-            "%usage": 8.0
+            "%usage": 100.0
         }
     },
     "fans": {},
     "memory": {
-        "available_ram": 40.5,
-        "used_ram": 59.5
+        "available_ram": 90.0,
+        "used_ram": 10.0
         },
     "power": {},
     "temperature": {}

--- a/test/unit/validate/mocked_data/non_strict_fail/report.yml
+++ b/test/unit/validate/mocked_data/non_strict_fail/report.yml
@@ -88,3 +88,41 @@ get_route_to:
         present: []
       nested: true
 skipped: []
+
+get_environment:
+  complies: false
+  extra: []
+  missing: []
+  present:
+    cpu: 
+      complies: False
+      diff: 
+        complies: False
+        extra: []
+        missing: []
+        present: 
+          0/RP0/CPU0:
+            complies: False
+            diff: 
+              complies: False
+              extra: []
+              missing: []
+              present: 
+                '%usage': 
+                  actual_value: 100.0
+                  complies: False
+                  nested: False
+            nested: True
+      nested: True
+    memory: 
+      complies: False
+      diff: 
+        complies: False
+        extra: []
+        missing: []
+        present: 
+          available_ram: 
+            actual_value: 90.0
+            complies: False
+            nested: False
+      nested: True

--- a/test/unit/validate/mocked_data/non_strict_fail/validate.yml
+++ b/test/unit/validate/mocked_data/non_strict_fail/validate.yml
@@ -37,3 +37,10 @@
        - next_hop: 10.155.180.22
          outgoing_interface: "irb.0"
          protocol: "OSPF"
+
+- get_environment:
+    memory:
+      available_ram: "<20.0"
+    cpu:
+      0/RP0/CPU0:
+        "%usage": "<20.0"

--- a/test/unit/validate/mocked_data/non_strict_pass/get_environment.json
+++ b/test/unit/validate/mocked_data/non_strict_pass/get_environment.json
@@ -1,0 +1,14 @@
+{
+    "cpu": {
+        "0/RP0/CPU0": {
+            "%usage": 15.0
+        }
+    },
+    "fans": {},
+    "memory": {
+        "available_ram": 10.0,
+        "used_ram": 90.0
+        },
+    "power": {},
+    "temperature": {}
+ }

--- a/test/unit/validate/mocked_data/non_strict_pass/report.yml
+++ b/test/unit/validate/mocked_data/non_strict_pass/report.yml
@@ -27,3 +27,10 @@ get_route_to:
   missing: []
   present:
     10.155.180.192/26: {complies: true, nested: true}
+get_environment:
+  complies: true
+  extra: []
+  missing: []
+  present:
+    cpu: {complies: true, nested: true}
+    memory: {complies: true, nested: true}

--- a/test/unit/validate/mocked_data/non_strict_pass/validate.yml
+++ b/test/unit/validate/mocked_data/non_strict_pass/validate.yml
@@ -35,3 +35,10 @@
        - next_hop: 10.155.180.22
          outgoing_interface: "irb.0"
          protocol: "BGP"
+
+- get_environment:
+    memory:
+      available_ram: "<20.0"
+    cpu:
+      0/RP0/CPU0:
+        "%usage": "<20.0"

--- a/test/unit/validate/mocked_data/strict_pass/get_environment.json
+++ b/test/unit/validate/mocked_data/strict_pass/get_environment.json
@@ -1,0 +1,14 @@
+{
+    "cpu": {
+        "0/RP0/CPU0": {
+            "%usage": 8.0
+        }
+    },
+    "fans": {},
+    "memory": {
+        "available_ram": 40.5,
+        "used_ram": 59.5
+        },
+    "power": {},
+    "temperature": {}
+ }

--- a/test/unit/validate/mocked_data/strict_pass/report.yml
+++ b/test/unit/validate/mocked_data/strict_pass/report.yml
@@ -47,3 +47,10 @@ get_lldp_neighbors:
   present:
     ge-1/0/2: {complies: true, nested: false}
     ge-1/0/3: {complies: true, nested: False}
+get_environment:
+  complies: true
+  extra: []
+  missing: []
+  present:
+    cpu: {complies: true, nested: true}
+    memory: {complies: true, nested: true}

--- a/test/unit/validate/mocked_data/strict_pass/report.yml
+++ b/test/unit/validate/mocked_data/strict_pass/report.yml
@@ -47,10 +47,3 @@ get_lldp_neighbors:
   present:
     ge-1/0/2: {complies: true, nested: false}
     ge-1/0/3: {complies: true, nested: False}
-get_environment:
-  complies: true
-  extra: []
-  missing: []
-  present:
-    cpu: {complies: true, nested: true}
-    memory: {complies: true, nested: true}

--- a/test/unit/validate/mocked_data/strict_pass/validate.yml
+++ b/test/unit/validate/mocked_data/strict_pass/validate.yml
@@ -68,3 +68,10 @@
     ge-1/0/3:
       - hostname: "border2.private.lon2"
         port: "519"
+
+- get_environment:
+    memory:
+      available_ram: ">15.0"
+    cpu:
+      0/RP0/CPU0:
+        "%usage": "<10.0"

--- a/test/unit/validate/mocked_data/strict_pass/validate.yml
+++ b/test/unit/validate/mocked_data/strict_pass/validate.yml
@@ -68,10 +68,3 @@
     ge-1/0/3:
       - hostname: "border2.private.lon2"
         port: "519"
-
-- get_environment:
-    memory:
-      available_ram: ">15.0"
-    cpu:
-      0/RP0/CPU0:
-        "%usage": "<10.0"


### PR DESCRIPTION
Hi,
I needed numeric compare when pre-post validate such as cpu_use,memory_available.
for example, less than memory 50% is executed by commit_config.

* modified: _compare_getter_dict
* add method: compare_numeric
* add test: get_environment  