### PR TITLE
Add always_alive decorator

### DIFF
--- a/napalm_base/decorators.py
+++ b/napalm_base/decorators.py
@@ -10,19 +10,17 @@ from functools import wraps
 
 def always_alive(fun):
     def _connection_alive(obj):
-        _alive = True
-        _default_alive_method = lambda: True
         try:
             _is_alive_method = getattr(obj, 'is_alive')
             _auto_reconnect = getattr(obj, 'auto_reconnect')
             if not _auto_reconnect:
                 # if not requested to check if the connection is alive
-                _is_alive_method = _default_alive_method
+                return True
         except AttributeError:
-                _is_alive_method = _default_alive_method
-                # if not implemented in the driver, will just assume it is connected...
-        _alive = _is_alive_method()
-        return _alive
+            # if not implemented in the driver, will just assume it is connected...
+            return True
+        return _is_alive_method()
+
     @wraps(fun)
     def _always_alive_wrapper(*args, **kwargs):
         _obj = args[0]  # instance of driver class

--- a/napalm_base/decorators.py
+++ b/napalm_base/decorators.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+'''
+Decorators for napalm methods.
+'''
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from functools import wraps
+
+
+def always_alive(fun):
+    def _connection_alive(obj):
+        _alive = True
+        _default_alive_method = lambda: True
+        try:
+            _is_alive_method = getattr(obj, 'is_alive')
+            _auto_reconnect = getattr(obj, 'auto_reconnect')
+            if not _auto_reconnect:
+                # if not requested to check if the connection is alive
+                _is_alive_method = _default_alive_method
+        except AttributeError:
+                _is_alive_method = _default_alive_method
+                # if not implemented in the driver, will just assume it is connected...
+        _alive = _is_alive_method()
+        return _alive
+    @wraps(fun)
+    def _always_alive_wrapper(*args, **kwargs):
+        _obj = args[0]  # instance of driver class
+        _alive = _connection_alive(_obj)
+        if not _alive:
+            _obj.open()
+        return fun(*args, **kwargs)
+    return _always_alive_wrapper


### PR DESCRIPTION
Following discussion from https://github.com/napalm-automation/napalm-ios/pull/152

Defining this decorator which checks the status of the connection before trying to execute the actual method. If the transport layer is unusable, it will (re)open the session.
It checks for the private property `auto_reconnect` which is set in the driver from the optional args (i.e. `self.auto_reconnect = optional_args['auto_reconnect']` etc.). If not defined, will default it to `False` behavior and does not execute the alive check. Similarly, if the `is_alive` method is not defined, it will consider the connection as up and doesn't try to perform anything.

Usage example:

```python
@always_alive
def get_lldp_neighbors(self):
```

I have been using a slightly different version of this decorator in production for almost one year, without seeing any issues.

@ktbyers and @dbarrosop I know you'll have objections, Kirk probably very strong, but please let's try to be constructive and provide something useful for the users.
