### PR TITLE
session_keepalive method base

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -115,6 +115,13 @@ class NetworkDriver(object):
         """
         raise NotImplementedError
 
+    def anti_idle(self):
+        """
+        Send a special character over the transport channel
+        to make sure the device doesn't drop the connection.
+        """
+        raise NotImplementedError
+
     def load_template(self, template_name, template_source=None,
                       template_path=None, **template_vars):
         """

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -115,7 +115,7 @@ class NetworkDriver(object):
         """
         raise NotImplementedError
 
-    def anti_idle(self):
+    def session_keepalive(self):
         """
         Send a special character over the transport channel
         to make sure the device doesn't drop the connection.


### PR DESCRIPTION
This PR introduces a new method as discussed under https://github.com/napalm-automation/napalm-ios/pull/152.
Apparently, the only way to maintain the connection alive with the remote device is sending a special character at regular intervals.
This method only sends the special sequence, does not handle any timing etc. Under the `napalm-ios` driver, the implementation would be as simple as:

```python
def anti_idle(self):
    self.write_channel(chr(0))
```