### PR TITLE
Fix the as_number helper

### DIFF
--- a/napalm_base/helpers.py
+++ b/napalm_base/helpers.py
@@ -248,10 +248,11 @@ def ip(addr, version=None):
     return py23_compat.text_type(addr_obj)
 
 
-def as_number(as_number):
+def as_number(as_number_val):
     """Convert AS Number to standardized asplain notation as an integer."""
-    if '.' in as_number:
-        big, little = as_number.split('.')
+    as_number_str = py23_compat.text_type(as_number_val)
+    if '.' in as_number_str:
+        big, little = as_number_str.split('.')
         return (int(big) << 16) + int(little)
     else:
-        return int(as_number)
+        return int(as_number_str)

--- a/test/unit/TestHelpers.py
+++ b/test/unit/TestHelpers.py
@@ -316,6 +316,7 @@ class TestBaseHelpers(unittest.TestCase):
         self.assertEqual(napalm_base.helpers.as_number('1.100'), 65636)
         self.assertEqual(napalm_base.helpers.as_number('1.65535'), 131071)
         self.assertEqual(napalm_base.helpers.as_number('65535.65535'), 4294967295)
+        self.assertEqual(napalm_base.helpers.as_number(64001), 64001)
 
     def test_convert_uptime_string_seconds(self):
         """


### PR DESCRIPTION
- confusing variable and function have the same name
- fails when the value is already an integer