### PR TITLE
Validate using python object

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -29,7 +29,6 @@ from napalm_base import validate
 
 
 class NetworkDriver(object):
-
     def __init__(self, hostname, username, password, timeout=60, optional_args=None):
         """
         This is the base class you have to inherit from when writing your own Network Driver to
@@ -1538,11 +1537,17 @@ class NetworkDriver(object):
         """
         raise NotImplementedError
 
-    def compliance_report(self, validation_file='validate.yml'):
+    def compliance_report(self, validation_file=None, validation_source=None):
         """
         Return a compliance report.
 
         Verify that the device complies with the given validation file and writes a compliance
         report file. See https://napalm.readthedocs.io/en/latest/validate.html.
+
+        :param validation_file: Path to the file containing compliance definition. Default is None.
+        :param validation_source: Dictionary containing compliance rules.
+        :raise ValidationException: File is not valid.
+        :raise NotImplementedError: Method not implemented.
         """
-        return validate.compliance_report(self, validation_file=validation_file)
+        return validate.compliance_report(self, validation_file=validation_file,
+                                          validation_source=validation_source)

--- a/napalm_base/validate.py
+++ b/napalm_base/validate.py
@@ -153,9 +153,10 @@ def empty_tree(input_list):
     return True
 
 
-def compliance_report(cls, validation_file=None):
+def compliance_report(cls, validation_file=None, validation_source=None):
     report = {}
-    validation_source = _get_validation_file(validation_file)
+    if validation_file:
+        validation_source = _get_validation_file(validation_file)
 
     for validation_check in validation_source:
         for getter, expected_results in validation_check.items():

--- a/test/unit/validate/test_validate.py
+++ b/test/unit/validate/test_validate.py
@@ -38,6 +38,17 @@ class TestValidate:
 
         assert expected_report == actual_report, yaml.safe_dump(actual_report)
 
+    def test_non_strict_pass_from_source(self):
+        """A simple test."""
+        mocked_data = os.path.join(BASEPATH, "mocked_data", "non_strict_pass")
+        expected_report = _read_yaml(os.path.join(mocked_data, "report.yml"))
+
+        device = FakeDriver(mocked_data)
+        source = _read_yaml(os.path.join(mocked_data, "validate.yml"))
+        actual_report = device.compliance_report(validation_source=source)
+
+        assert expected_report == actual_report, yaml.safe_dump(actual_report)
+
     def test_non_strict_fail(self):
         """A simple test."""
         mocked_data = os.path.join(BASEPATH, "mocked_data", "non_strict_fail")
@@ -45,6 +56,17 @@ class TestValidate:
 
         device = FakeDriver(mocked_data)
         actual_report = device.compliance_report(os.path.join(mocked_data, "validate.yml"))
+
+        assert expected_report == actual_report, yaml.safe_dump(actual_report)
+
+    def test_non_strict_fail_from_source(self):
+        """A simple test."""
+        mocked_data = os.path.join(BASEPATH, "mocked_data", "non_strict_fail")
+        expected_report = _read_yaml(os.path.join(mocked_data, "report.yml"))
+
+        device = FakeDriver(mocked_data)
+        source = _read_yaml(os.path.join(mocked_data, "validate.yml"))
+        actual_report = device.compliance_report(validation_source=source)
 
         assert expected_report == actual_report, yaml.safe_dump(actual_report)
 
@@ -58,6 +80,17 @@ class TestValidate:
 
         assert expected_report == actual_report, yaml.safe_dump(actual_report)
 
+    def test_strict_fail_from_source(self):
+        """A simple test."""
+        mocked_data = os.path.join(BASEPATH, "mocked_data", "strict_fail")
+        expected_report = _read_yaml(os.path.join(mocked_data, "report.yml"))
+
+        device = FakeDriver(mocked_data)
+        source = _read_yaml(os.path.join(mocked_data, "validate.yml"))
+        actual_report = device.compliance_report(validation_source=source)
+
+        assert expected_report == actual_report, yaml.safe_dump(actual_report)
+
     def test_strict_pass(self):
         """A simple test."""
         mocked_data = os.path.join(BASEPATH, "mocked_data", "strict_pass")
@@ -68,6 +101,17 @@ class TestValidate:
 
         assert expected_report == actual_report, yaml.safe_dump(actual_report)
 
+    def test_strict_pass_from_source(self):
+        """A simple test."""
+        mocked_data = os.path.join(BASEPATH, "mocked_data", "strict_pass")
+        expected_report = _read_yaml(os.path.join(mocked_data, "report.yml"))
+
+        device = FakeDriver(mocked_data)
+        source = _read_yaml(os.path.join(mocked_data, "validate.yml"))
+        actual_report = device.compliance_report(validation_source=source)
+
+        assert expected_report == actual_report, yaml.safe_dump(actual_report)
+
     def test_strict_pass_skip(self):
         """A simple test."""
         mocked_data = os.path.join(BASEPATH, "mocked_data", "strict_pass_skip")
@@ -75,6 +119,17 @@ class TestValidate:
 
         device = FakeDriver(mocked_data)
         actual_report = device.compliance_report(os.path.join(mocked_data, "validate.yml"))
+
+        assert expected_report == actual_report, yaml.safe_dump(actual_report)
+
+    def test_strict_pass_skip_from_source(self):
+        """A simple test."""
+        mocked_data = os.path.join(BASEPATH, "mocked_data", "strict_pass_skip")
+        expected_report = _read_yaml(os.path.join(mocked_data, "report.yml"))
+
+        device = FakeDriver(mocked_data)
+        source = _read_yaml(os.path.join(mocked_data, "validate.yml"))
+        actual_report = device.compliance_report(validation_source=source)
 
         assert expected_report == actual_report, yaml.safe_dump(actual_report)
 


### PR DESCRIPTION
Having the validation format in a single place makes the validation
constrained by placing the content only on a single file,
on the local disk.
There are many applicabilities where we need to test with remote
content, or any other source.
This is making the validator more flexible