### PR TITLE
Added integration with napalm-yang

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -22,13 +22,14 @@ import sys
 # local modules
 import napalm_base.exceptions
 import napalm_base.helpers
+import napalm_base.yang
 
 import napalm_base.constants as c
 
 from napalm_base import validate
 
 
-class NetworkDriver(object):
+class NetworkDriver(napalm_base.yang.NapalmYangIntegration):
 
     def __init__(self, hostname, username, password, timeout=60, optional_args=None):
         """

--- a/napalm_base/yang.py
+++ b/napalm_base/yang.py
@@ -1,0 +1,105 @@
+# Copyright 2017 Dravetech AB. All rights reserved.
+#
+# The contents of this file are licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Python3 support
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import napalm_yang
+
+
+# TODO this should come from napalm-yang
+# TODO we probably need to adapt the validate framework as well
+SUPPORTED_MODELS = [
+    "openconfig-interfaces",
+    "openconfig-network-instance",
+]
+
+
+class NapalmYangIntegration(object):
+
+    @property
+    def yang(self):
+        if not hasattr(self, "config"):
+            self.config = Yang("config", self)
+            self.state = Yang("state", self)
+        return self
+
+
+class Yang(object):
+
+    def __init__(self, mode, device):
+        self._mode = mode
+        self.device = device
+        self.device.running = napalm_yang.base.Root()
+
+        if mode == "config":
+            self.device.candidate = napalm_yang.base.Root()
+
+        for model in SUPPORTED_MODELS:
+            model = model.replace("-", "_")
+            funcname = "get_{}".format(model)
+            setattr(Yang, funcname, yang_get_wrapper(model))
+
+    def translate(self, merge=False, replace=False, profile=None):
+        if profile is None:
+            profile = self.device.profile
+
+        if merge:
+            return self.device.candidate.translate_config(profile=profile,
+                                                          merge=self.device.running)
+        elif replace:
+            return self.device.candidate.translate_config(profile=profile,
+                                                          replace=self.device.running)
+        else:
+            return self.device.candidate.translate_config(profile=profile)
+
+    def diff(self):
+        return napalm_yang.utils.diff(self.device.candidate, self.device.running)
+
+
+def yang_get_wrapper(model):
+    def method(self, **kwargs):
+
+        # This is the class for the model
+        modelobj = getattr(napalm_yang.models, model)()
+
+        # We attach it to the running object
+        self.device.running.add_model(modelobj)
+
+        # We extract the attribute assigned to the running object
+        # for example, device.running.interfaces
+        modelattr = getattr(self.device.running, modelobj.elements().keys()[0])
+
+        # We get the correct method (parse_config or parse_state)
+        parsefunc = getattr(self.device.running, "parse_{}".format(self._mode))
+
+        # We parse *only* the model that corresponds to this call
+        parsefunc(device=self.device, attrs=[modelattr])
+
+        # If we are in configuration mode and the user requests it
+        # we create a candidate as well
+        if kwargs.pop("candidate"):
+            modelobj = getattr(napalm_yang.models, model)()
+            self.device.candidate.add_model(modelobj)
+            modelattr = getattr(self.device.candidate, modelobj.elements().keys()[0])
+            parsefunc = getattr(self.device.candidate, "parse_{}".format(self._mode))
+            parsefunc(device=self.device, attrs=[modelattr])
+
+        # In addition to populate the running object, we return a dict with the contents
+        # of the parsed model
+        f = kwargs.get("filter", True)
+        return modelattr.get(filter=f)
+
+    return method

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jtextfsm
 jinja2
 netaddr
 pyYAML
+napalm-yang

--- a/test.py
+++ b/test.py
@@ -1,0 +1,57 @@
+from napalm_base import get_network_driver
+
+import json
+
+
+def pretty_print(dictionary):
+    print(json.dumps(dictionary, sort_keys=True, indent=4))
+
+
+eos_configuration = {
+    'hostname': '127.0.0.1',
+    'username': 'vagrant',
+    'password': 'vagrant',
+    'optional_args': {'port': 12443}
+}
+
+eos = get_network_driver("eos")
+eos_device = eos(**eos_configuration)
+
+eos_device.open()
+pretty_print(eos_device.yang.config.get_openconfig_interfaces(candidate=True))
+#  print(eos_device.yang.config.get_openconfig_network_instance())
+
+print("# Raw translation")
+print(eos_device.yang.config.translate())
+print("-------------")
+
+print("# Merge without changes, should be empty")
+print(eos_device.yang.config.translate(merge=True))
+print("-------------")
+
+print("# Replace without changes, should be empty")
+print(eos_device.yang.config.translate(replace=True))
+print("-------------")
+
+
+print("# Change a description")
+eos_device.candidate.interfaces.interface["Ethernet1"].config.description = "This is a new description"
+pretty_print(eos_device.config.diff())
+print("-------------")
+
+print("# Merge change")
+print(eos_device.yang.config.translate(merge=True))
+print("-------------")
+
+print("# Replace change")
+replace_config = eos_device.yang.config.translate(replace=True)
+print(replace_config)
+print("-------------")
+
+print("# Let's replace the current interfaces configuration from the device")
+eos_device.load_merge_candidate(config=replace_config)
+print(eos_device.compare_config())
+eos_device.discard_config()
+print("-------------")
+
+eos_device.close()


### PR DESCRIPTION
DO NOT MERGE

Depends on napalm-automation/napalm-yang#61

This PR integrates napalm-yang into the drivers. See:

https://github.com/napalm-automation/napalm-base/compare/dbarrosop/napalm-yang?expand=1#diff-b284a28710cce90d9d9be3a7f4cabc8e

(gist with the execution https://gist.github.com/dbarrosop/8fae309ecbfe7d1207044aca5732beba)

"getters" are dynamic which means there is no dependency loop between napalm-yang and the drivers themselves. I just have to move the `SUPPORTED_MODELS` to `napalm-yang` which I will do once we are happy with the PR.

@mirceaulinic @ktbyers thoughts?