### PR TITLE
Added AttributeError Exception to __del__ function in NetworkDriver

### DIFF
--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -68,6 +68,8 @@ class NetworkDriver(object):
         try:
             if self.is_alive()["is_alive"]:
                 self.close()
+        except AttributeError:
+            pass
         except NotImplementedError:
             pass
 

--- a/napalm_base/base.py
+++ b/napalm_base/base.py
@@ -68,9 +68,7 @@ class NetworkDriver(object):
         try:
             if self.is_alive()["is_alive"]:
                 self.close()
-        except AttributeError:
-            pass
-        except NotImplementedError:
+        except Exception:
             pass
 
     @staticmethod


### PR DESCRIPTION
This commit fixes Issue #267:
[https://github.com/napalm-automation/napalm-base/issues/267](url)

Adding an exception handler for AttributeError allows the script to complete. 