### PR TITLE
Added a framework to be able to diff shitty/ios config

### DIFF
--- a/napalm_base/indent_differ.py
+++ b/napalm_base/indent_differ.py
@@ -1,0 +1,140 @@
+from napalm_base.utils import py23_compat
+
+import re
+
+
+def parse_indented_config(config, current_indent=0, previous_indent=0, nested=False):
+    parsed = IndentedConfig()
+    while True:
+        if not config:
+            break
+        line = config.pop(0)
+        last = line.lstrip()
+        leading_spaces = len(line) - len(last)
+
+        #  print("current_indent:{}, previous:{}, leading:{} - {}".format(
+        #        current_indent, previous_indent, leading_spaces, line))
+
+        if leading_spaces > current_indent:
+            parsed[last] = parse_indented_config(config, leading_spaces, current_indent, True)
+        elif leading_spaces < current_indent:
+            config.insert(0, line)
+            break
+        else:
+            if not nested:
+                parsed[last] = parse_indented_config(config, leading_spaces, current_indent, True)
+            else:
+                config.insert(0, line)
+                break
+
+    return parsed
+
+
+def _can_have_multiple(command):
+    EXACT_MATCHES = [
+        "interface",
+        "router",
+        "access-list",
+        "policy-map",
+        "ip prefix",
+        "ipv6 prefix",
+        "neighbor",
+        "ip address",
+        "ipv6 address",
+    ]
+    return any([command.startswith(e) for e in EXACT_MATCHES])
+
+
+def _expand(d, action, indent):
+    result = []
+    for k, v in d.items():
+        k = "{}{}".format(" " * indent * 2, k)
+        result.append((action, k))
+        result += _expand(v, action, indent+1)
+    return result
+
+
+def merge(running, candidate, negators, indent=0):
+    result = []
+    for command, subcommands in candidate.items():
+        if any([command.startswith(n) for n in negators]):
+            ncmd = " ".join(command.split(" ")[1:])
+            remove = running.find(ncmd, exact=_can_have_multiple(ncmd))
+            for r in remove:
+                result.append(("remove", "{}{}".format(" " * indent * 2, r)))
+                result += _expand(running[r], "remove", indent+1)
+        elif command in running:
+            r = merge(running[command], subcommands, negators, indent+1)
+            if r:
+                result.append(("change", command))
+                result += r
+        elif command not in running:
+            result.append(("add", "{}{}".format(" " * indent * 2, command)))
+            result += _expand(subcommands, "add", indent+1)
+
+            remove = running.find(command, exact=_can_have_multiple(command))
+            for r in remove:
+                result.append(("remove", "{}{}".format(" " * indent * 2, r)))
+                result += _expand(running[r], "remove", indent+1)
+
+    return result
+
+
+class IndentedConfig(object):
+
+    def __init__(self, config=None, comments="!", negators=["no", "default"]):
+        self.config = config if config is not None else ""
+
+        if self.config:
+            # let's get rid of empty lines and comments
+            lines_no_blanks = [line for line in self.config.splitlines()
+                               if line.strip() and not line.startswith(comments)]
+            self.parsed = parse_indented_config(lines_no_blanks)
+        else:
+            self.parsed = {}
+        self.negators = negators
+
+    def items(self):
+        return self.parsed.items()
+
+    def keys(self):
+        return self.parsed.keys()
+
+    def values(self):
+        return self.parsed.values()
+
+    def __setitem__(self, item, value):
+        self.parsed.__setitem__(item, value)
+
+    def __getitem__(self, item):
+        return self.parsed.__getitem__(item)
+
+    def __contains__(self, key):
+        return key in self.parsed
+
+    def to_dict(self):
+        result = {}
+        for k, v in self.items():
+            if v:
+                result[k] = v.to_dict()
+            else:
+                result[k] = {}
+        return result
+
+    def find(self, command, exact):
+        if not exact:
+            cmd = " ".join(command.split(" ")[0:-1])
+            command = cmd if cmd else command
+        regex = re.compile("^{}.*".format(command))
+        return [c for c in self.keys() if regex.match(c)]
+
+    def diff(self, candidate):
+        if isinstance(candidate, py23_compat.string_types):
+            candidate = IndentedConfig(candidate)
+        result = merge(self, candidate, self.negators)
+        m = {
+            "remove": "-",
+            "add": "+",
+            "change": " ",
+        }
+        return "\n".join(["{} {}".format(m[r[0]], r[1]) for r in result])

--- a/test/unit/test_indent_differ.py
+++ b/test/unit/test_indent_differ.py
@@ -1,0 +1,82 @@
+from napalm_base import get_network_driver
+from napalm_base import indent_differ
+
+import pytest
+
+import os
+
+
+BASE_PATH = os.path.dirname(__file__)
+
+
+driver = get_network_driver("mock")
+
+test_cases_differ = [
+    "test_case_1",
+]
+
+
+class Test_Indent_differ(object):
+    """Test Mock Driver."""
+
+    def test_parser(self):
+        candidate = '''
+enable password whatever
+
+interface Loopback0
+  description "blah"
+interface GigabitEthernet1
+  description "bleh"
+
+  fake nested
+    nested nested configuration
+
+  switchport mode trunk
+
+interface GigabitEthernet2
+  no ip address
+
+interface GigabitEthernet3
+ no ip address
+ shutdown
+
+ negotiation auto'''
+
+        parsed = indent_differ.IndentedConfig(candidate)
+
+        expected = {'enable password whatever': {},
+                    'interface GigabitEthernet1': {
+                        'description "bleh"': {},
+                        'fake nested': {
+                            'nested nested configuration': {}},
+                        'switchport mode trunk': {}},
+                    'interface GigabitEthernet2': {
+                        'no ip address': {}},
+                    'interface GigabitEthernet3': {
+                        'negotiation auto': {},
+                        'no ip address': {},
+                        'shutdown': {}},
+                    'interface Loopback0': {
+                        'description "blah"': {}}}
+
+        assert parsed.to_dict() == expected
+
+    @pytest.mark.parametrize("case", test_cases_differ)
+    def test_basic(self, case):
+        path = os.path.join(BASE_PATH, "test_indent_differ", case)
+        optional_args = {
+            "path": path,
+            "profile": ["mock"],
+        }
+
+        with driver("blah", "bleh", "blih", optional_args=optional_args) as d:
+            running = d.cli(["show running config"])["show running config"]
+
+        with open(os.path.join(path, "candidate.txt"), "r") as f:
+            candidate = f.read()
+
+        with open(os.path.join(path, "diff.txt"), "r") as f:
+            expected = f.read()
+
+        diff = indent_differ.IndentedConfig(running).diff(candidate)
+        assert diff.strip() == expected.strip()

--- a/test/unit/test_indent_differ/test_case_1/candidate.txt
+++ b/test/unit/test_indent_differ/test_case_1/candidate.txt
@@ -1,0 +1,17 @@
+enable password whatever
+default logging
+
+no interface Loopback0
+
+interface GigabitEthernet1
+  description "bleh"
+  switchport mode trunk
+  switchport trunk vlan 1,2,3,5
+
+interface GigabitEthernet2
+  no ip address
+
+no interface GigabitEthernet666
+
+router bgp 65000
+  no neighbor 1.1.1.1

--- a/test/unit/test_indent_differ/test_case_1/cli.1.show_running_config.0
+++ b/test/unit/test_indent_differ/test_case_1/cli.1.show_running_config.0
@@ -1,0 +1,139 @@
+version 15.4
+service timestamps debug datetime msec
+service timestamps log datetime msec
+no platform punt-keepalive disable-kernel-core
+platform console virtual
+!
+hostname vagrant_box
+!
+boot-start-marker
+boot-end-marker
+!
+!
+enable secret 5 $1$nc08$bizeEFbgCBKjZP4nurNCd.
+enable password vagrant
+!
+aaa new-model
+!
+!
+aaa authorization exec default local
+!
+!
+logging blah
+logging bleh
+!
+!
+!
+aaa session-id common
+!
+!
+!
+!
+!
+!
+!
+!
+!
+
+
+ip domain name acme.com
+
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+subscriber templating
+!
+multilink bundle-name authenticated
+!
+!
+!
+license udi pid CSR1000V sn 9EKBH55S58T
+archive
+ path bootflash:archive
+ write-memory
+spanning-tree extend system-id
+!
+username vagrant privilege 15 password 0 vagrant
+!
+redundancy
+ mode none
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+interface Loopback0
+ description something
+ ip address 1.1.1.1 255.255.255.255
+!
+interface GigabitEthernet1
+ ip address dhcp
+ negotiation auto
+ no mop enabled
+ switchport mode access
+ switchport trunk vlan 1,2,3,4,5
+!
+interface GigabitEthernet2
+ description blah
+ ip address 172.20.0.1 255.255.255.0
+ shutdown
+ negotiation auto
+!
+interface GigabitEthernet3
+ no ip address
+ shutdown
+ negotiation auto
+!
+router bgp 65000
+ bgp log-neighbor-changes
+ neighbor 1.1.1.1 remote-as 12345
+ neighbor 1.1.1.1 local-as 54321
+ neighbor 2.2.2.2 local-as 54321
+!
+!
+virtual-service csr_mgmt
+!
+ip forward-protocol nd
+!
+no ip http server
+no ip http secure-server
+ip ssh version 2
+ip scp server enable
+!
+!
+!
+!
+!
+!
+control-plane
+!
+!
+line con 0
+ stopbits 1
+line vty 0 4
+ password vagrant
+!
+!
+end

--- a/test/unit/test_indent_differ/test_case_1/diff.txt
+++ b/test/unit/test_indent_differ/test_case_1/diff.txt
@@ -1,0 +1,18 @@
+- interface Loopback0
+-   ip address 1.1.1.1 255.255.255.255
+-   description something
+  interface GigabitEthernet1
++   switchport mode trunk
+-   switchport mode access
++   switchport trunk vlan 1,2,3,5
+-   switchport trunk vlan 1,2,3,4,5
++   description "bleh"
+  router bgp 65000
+-   neighbor 1.1.1.1 remote-as 12345
+-   neighbor 1.1.1.1 local-as 54321
+  interface GigabitEthernet2
+-   ip address 172.20.0.1 255.255.255.0
+- logging bleh
+- logging blah
++ enable password whatever
+- enable password vagrant


### PR DESCRIPTION
This framework does two things:

1. Given a nested configuration it creates a nested structure:
https://github.com/napalm-automation/napalm-base/compare/indent_differ?expand=1#diff-cae653bb93fa20df55fada139a153965R22
2. Adds code to be able to diff two `IndentedConfig` objects.

What I would like to do is to people help testing (2). To do it you need to create a folder like this one; `test/unit/test_indent_differ/test_case_1/`. Inside, you have to put three files:

1. `cli.1.show_running_config.0`. A configuration file retrieved from a device with a poor configuration model like IOS uses.
2. `candidate.txt`. A bunch of commands you want to merge on the device.
3. `diff.txt`. The expected diff.

Finally, just add the folder name here: https://github.com/napalm-automation/napalm-base/compare/indent_differ?expand=1#diff-cae653bb93fa20df55fada139a153965R14 and run the test with `py.test test/unit/test_indent_differ.py::Test_Indent_differ`

