### PR TITLE
Tests for config under snmp-server (for #277)

### DIFF
--- a/napalm_base/indent_differ.py
+++ b/napalm_base/indent_differ.py
@@ -66,6 +66,7 @@ def _can_have_multiple(command):
         "neighbor",
         "ip address",
         "ipv6 address",
+        "snmp-server enable traps",
     ]
     return any([command.startswith(e) for e in EXACT_MATCHES])
 

--- a/test/unit/test_indent_differ.py
+++ b/test/unit/test_indent_differ.py
@@ -14,6 +14,7 @@ driver = get_network_driver("mock")
 test_cases_differ = [
     "test_case_1",
     "test_case_2",
+    "test_snmp_server",
 ]
 
 

--- a/test/unit/test_indent_differ/test_snmp_server/candidate.txt
+++ b/test/unit/test_indent_differ/test_snmp_server/candidate.txt
@@ -1,0 +1,5 @@
+snmp-server location DEMO_ENV
+snmp-server contact NAPALM-NOC_DEMO
+snmp-server community napalm RO
+snmp-server community public RO 10
+snmp-server enable traps entity-sensor

--- a/test/unit/test_indent_differ/test_snmp_server/cli.1.show_running_config.0
+++ b/test/unit/test_indent_differ/test_snmp_server/cli.1.show_running_config.0
@@ -1,0 +1,169 @@
+version 16.4
+service config
+service timestamps debug datetime msec
+service timestamps log datetime msec
+no platform punt-keepalive disable-kernel-core
+platform console auto
+!
+hostname R1
+!
+boot-start-marker
+boot-end-marker
+!
+!
+enable secret 5 $1$eDEi$pZFFuuwLSgnnhBmg2XdrD0
+!
+aaa new-model
+!
+!
+aaa authentication login LOCALDB local
+aaa authorization exec LOCALAUTHZ local
+aaa authorization network LOCALAUTHZ local
+!
+!
+!
+!
+!
+aaa session-id common
+!
+!
+!
+!
+!
+!
+!
+!
+!
+
+
+
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+subscriber templating
+!
+!
+!
+multilink bundle-name authenticated
+!
+!
+!
+!
+!
+!
+
+
+!
+!
+!
+!
+!
+!
+!
+license udi pid CSR1000V sn 9N6NA9WRBAW
+diagnostic bootup level minimal
+!
+spanning-tree extend system-id
+!
+!
+username vagrant privilege 15 secret 5 $1$hoD9$fiXAskKgXkVfP9bJ0d4Oy1
+!
+redundancy
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+!
+interface GigabitEthernet1
+ ip address dhcp
+ negotiation auto
+ no mop enabled
+ no mop sysid
+!
+interface GigabitEthernet2
+ no ip address
+ shutdown
+ negotiation auto
+ no mop enabled
+ no mop sysid
+!
+interface GigabitEthernet3
+ no ip address
+ shutdown
+ negotiation auto
+ no mop enabled
+ no mop sysid
+!
+!
+virtual-service csr_mgmt
+!
+ip forward-protocol nd
+no ip http server
+no ip http secure-server
+!
+!
+!
+access-list 10 permit 10.10.10.12
+!
+!
+snmp-server community public RO
+snmp-server location VAGRANT
+snmp-server contact NAPALM-NOC
+snmp-server enable traps entity
+!
+!
+!
+!
+control-plane
+!
+ !
+ !
+ !
+ !
+!
+!
+!
+!
+!
+line con 0
+ stopbits 1
+line vty 0 4
+ authorization exec LOCALAUTHZ
+ login authentication LOCALDB
+!
+ntp server pool.ntp.org
+!
+!
+!
+!
+!
+end

--- a/test/unit/test_indent_differ/test_snmp_server/diff.txt
+++ b/test/unit/test_indent_differ/test_snmp_server/diff.txt
@@ -1,0 +1,8 @@
++ snmp-server community public RO 10
+- snmp-server community public RO
++ snmp-server contact NAPALM-NOC_DEMO
+- snmp-server contact NAPALM-NOC
++ snmp-server location DEMO_ENV
+- snmp-server location VAGRANT
++ snmp-server community napalm RO
++ snmp-server enable traps entity-sensor


### PR DESCRIPTION
An additional test for #277. It's nice that the code knows how to handle the added `snmp-server community public RO 10` line correctly.

However it doesn't work for the added `snmp-server enable traps entity-sensor` as it thinks it's supposed to delete `snmp-server enable traps entity`. 

There will be a number of these scenarios, probably "a lot". In some instances it will also surely differ between various platforms.