### PR TITLE
Indent diff cases

### DIFF
--- a/napalm_base/indent_differ.py
+++ b/napalm_base/indent_differ.py
@@ -100,6 +100,7 @@ def merge(running, candidate, negators, indent=0):
             for r in remove:
                 result.append(("remove", "{}{}".format(" " * indent * 2, r)))
                 result += _expand(running[r], "remove", indent+1)
+                running.pop(r)
         elif command in running:
             r = merge(running[command], subcommands, negators, indent+1)
             if r:
@@ -139,6 +140,9 @@ class IndentedConfig(object):
 
     def values(self):
         return self.parsed.values()
+
+    def pop(self, key):
+        self.parsed.pop(key)
 
     def __setitem__(self, item, value):
         self.parsed.__setitem__(item, value)

--- a/napalm_base/indent_differ.py
+++ b/napalm_base/indent_differ.py
@@ -69,6 +69,8 @@ def _can_have_multiple(command):
         "ip address",
         "ipv6 address",
         "snmp-server enable traps",
+        "ipv6 access-list",
+        "standby",
     ]
     return any([command.startswith(e) for e in EXACT_MATCHES])
 

--- a/test/unit/test_indent_differ/test_case_ipv6/candidate.txt
+++ b/test/unit/test_indent_differ/test_case_ipv6/candidate.txt
@@ -1,0 +1,18 @@
+no ipv6 access-list CISCO
+ipv6 access-list CISCO
+ deny tcp any any gt 5000
+ deny udp ::/0 lt 5000 ::/0 log
+ permit icmp any any
+ permit ipv6 any any
+
+interface GigabitEthernet0/0
+ ipv6 nd nud retry 1 1000 4
+interface GigabitEthernet0/1
+ no standby 2 preempt
+ ipv6 address 2001:DB8:CAFE:ABBA:BEEF::3/64
+interface GigabitEthernet0/2
+ no shutdown
+ ipv6 traffic-filter eigrp out
+
+no ipv6 route 2001:DB8::/48 GigabitEthernet0/2 FE80::3
+ipv6 route 2001:DB8::/48 GigabitEthernet0/4 FE80::5

--- a/test/unit/test_indent_differ/test_case_ipv6/cli.1.show_running_config.0
+++ b/test/unit/test_indent_differ/test_case_ipv6/cli.1.show_running_config.0
@@ -1,0 +1,136 @@
+!
+version 15.6
+service timestamps debug datetime msec
+service timestamps log datetime msec
+no service password-encryption
+!
+hostname R01
+!
+boot-start-marker
+boot-end-marker
+!
+!
+vrf definition mgmt
+ !
+ address-family ipv4
+ exit-address-family
+!
+!
+no aaa new-model
+ethernet lmi ce
+!
+no ip domain lookup
+ip domain name lab.local
+ip cef
+ipv6 icmp error-interval 3000 100
+ipv6 unicast-routing
+ipv6 cef
+!
+multilink bundle-name authenticated
+!
+!
+!
+!
+username test privilege 15 password 0 test
+!
+redundancy
+!
+!
+!
+interface GigabitEthernet0/0
+ no ip address
+ duplex auto
+ speed auto
+ media-type rj45
+ ipv6 address FE80::1 link-local
+ ipv6 address 2001:DB8:BEEF::1/64
+ ipv6 nd cache expire 7200
+ ipv6 nd nud retry 1 1000 3
+ ipv6 nd ra suppress
+!
+interface GigabitEthernet0/1
+ no ip address
+ standby version 2
+ standby 2 ipv6 2001:DB8:0:789:1::1/64
+ standby 2 priority 150
+ standby 2 preempt
+ duplex auto
+ speed auto
+ media-type rj45
+ ipv6 address 2001:DB8:0:789:1::3/64
+ ipv6 nd reachable-time 2700000
+ ipv6 nd na glean
+ ipv6 nd cache expire 7200
+ no ipv6 redirects
+!
+interface GigabitEthernet0/2
+ no ip address
+ shutdown
+ duplex auto
+ speed auto
+ media-type rj45
+ ipv6 traffic-filter CISCO in
+ ipv6 traffic-filter CISCO out
+!
+interface GigabitEthernet0/3
+ no ip address
+ shutdown
+ duplex auto
+ speed auto
+ media-type rj45
+!
+interface GigabitEthernet0/4
+ no ip address
+ shutdown
+ duplex auto
+ speed auto
+ media-type rj45
+!
+interface GigabitEthernet0/5
+ vrf forwarding mgmt
+ ip address 192.168.99.11 255.255.255.0
+ duplex auto
+ speed auto
+ media-type rj45
+!
+ip forward-protocol nd
+!
+!
+no ip http server
+no ip http secure-server
+ip route vrf mgmt 0.0.0.0 0.0.0.0 192.168.99.1
+!
+ipv6 route 2001:DB8::/48 GigabitEthernet0/3 FE80::4
+ipv6 route 2001:DB8::/48 GigabitEthernet0/2 FE80::3
+!
+!
+!
+ipv6 access-list CISCO
+ deny tcp any any gt 5000
+ permit icmp any any
+ permit ipv6 any any
+!
+ipv6 access-list eigrp
+ permit ipv6 any host FF02::A
+ deny ipv6 any any log
+!
+ipv6 access-list test1
+ deny ipv6 FE80::/64 any
+ permit ipv6 FE80::/64 any log
+!
+control-plane
+!
+line con 0
+line aux 0
+line vty 0 4
+ ipv6 access-class IPv6ACL in
+ login local
+ transport input ssh
+line vty 5 14
+ ipv6 access-class IPv6ACL in
+ login local
+ transport input ssh
+!
+no scheduler allocate
+!
+end

--- a/test/unit/test_indent_differ/test_case_ipv6/diff.txt
+++ b/test/unit/test_indent_differ/test_case_ipv6/diff.txt
@@ -1,21 +1,21 @@
 - ipv6 access-list CISCO
 -   deny tcp any any gt 5000
--   permit ipv6 any any
 -   permit icmp any any
-+  ipv6 access-list CISCO
+-   permit ipv6 any any
++ ipv6 access-list CISCO
 +   deny tcp any any gt 5000
 +   deny udp ::/0 lt 5000 ::/0 log
-+   permit ipv6 any any
 +   permit icmp any any
-  interface GigabitEthernet0/2
--   ipv6 traffic-filter CISCO out
-+   ipv6 traffic-filter eigrp out
--   shutdown
++   permit ipv6 any any
   interface GigabitEthernet0/0
 +   ipv6 nd nud retry 1 1000 4
 -   ipv6 nd nud retry 1 1000 3
   interface GigabitEthernet0/1
 -   standby 2 preempt
 +   ipv6 address 2001:DB8:CAFE:ABBA:BEEF::3/64
+  interface GigabitEthernet0/2
+-   shutdown
++   ipv6 traffic-filter eigrp out
+-   ipv6 traffic-filter CISCO out
 - ipv6 route 2001:DB8::/48 GigabitEthernet0/2 FE80::3
 + ipv6 route 2001:DB8::/48 GigabitEthernet0/4 FE80::5

--- a/test/unit/test_indent_differ/test_case_ipv6/diff.txt
+++ b/test/unit/test_indent_differ/test_case_ipv6/diff.txt
@@ -1,0 +1,21 @@
+- ipv6 access-list CISCO
+-   deny tcp any any gt 5000
+-   permit ipv6 any any
+-   permit icmp any any
++  ipv6 access-list CISCO
++   deny tcp any any gt 5000
++   deny udp ::/0 lt 5000 ::/0 log
++   permit ipv6 any any
++   permit icmp any any
+  interface GigabitEthernet0/2
+-   ipv6 traffic-filter CISCO out
++   ipv6 traffic-filter eigrp out
+-   shutdown
+  interface GigabitEthernet0/0
++   ipv6 nd nud retry 1 1000 4
+-   ipv6 nd nud retry 1 1000 3
+  interface GigabitEthernet0/1
+-   standby 2 preempt
++   ipv6 address 2001:DB8:CAFE:ABBA:BEEF::3/64
+- ipv6 route 2001:DB8::/48 GigabitEthernet0/2 FE80::3
++ ipv6 route 2001:DB8::/48 GigabitEthernet0/4 FE80::5


### PR DESCRIPTION
Add IPv6 use case

I didn't had time to fix the traffic-filter replacement issue.


running config
```
!
interface GigabitEthernet0/2
  no ip address
  ipv6 traffic-filter CISCO out
!
```
candidate
```
interface GigabitEthernet0/2
  ipv6 traffic-filter eigrp out
```
diff should be
```
interface GigabitEthernet0/2
-   ipv6 traffic-filter CISCO out
+  ipv6 traffic-filter eigrp out
```

diff is at the moment be
```
interface GigabitEthernet0/2
+  ipv6 traffic-filter eigrp out
```

The hole discussion: https://github.com/ubaumann/napalm-base/pull/1