### PR TITLE
Remove constraint on _rpc method for MockDriver

### DIFF
--- a/napalm_base/mock.py
+++ b/napalm_base/mock.py
@@ -187,11 +187,7 @@ class MockDriver(NetworkDriver):
         mocked_data(self.path, "discard_config", count)
 
     def _rpc(self, get):
-        """This one is only useful for junos."""
-        if "junos" in self.profile:
-            return self.cli([get]).values()[0]
-        else:
-            raise AttributeError("MockedDriver instance has not attribute '_rpc'")
+        return self.cli([get]).values()[0]
 
     def __getattribute__(self, name):
         if is_mocked_method(name):


### PR DESCRIPTION
The trend seems to be that more drivers will see the introduction of rpc oriented interfaces. This is especially true as things shift to model based configuration. This PR removes the junos constraint from the `_rpc` method in the MockDriver. 

The specific usecase is to allow `napalm-yang` tests work with an [iosxe](https://github.com/nickethier/napalm-iosxe) driver I'm developing. 
