### PR TITLE
An option to make napalm extendable

### DIFF
--- a/napalm_base/__init__.py
+++ b/napalm_base/__init__.py
@@ -96,7 +96,10 @@ def get_network_driver(module_name, prepend=True):
         # Can also request using napalm_[SOMETHING]
         if 'napalm_' not in module_install_name and prepend is True:
             module_install_name = 'napalm_{name}'.format(name=module_install_name)
-        module = importlib.import_module(module_install_name)
+        try:
+            module = importlib.import_module("custom_" + module_install_name)
+        except ImportError:
+            module = importlib.import_module(module_install_name)
     except ImportError:
         raise ModuleImportError(
                 'Cannot import "{install_name}". Is the library installed?'.format(


### PR DESCRIPTION
I briefly spoke to @ktbyers about this, and I do not expect this to go in as described here, just wanted to use it as the basis of discussion. 

Napalm's ability to work with multiple vendors is amazing, but I run into situations where I simply know my ask does not fit into a vendor neutral model or deals with proprietary one-off protocols. This is made more difficult when using ansible for instance, as I only have access to the defined getters... without modifying and managing that code.

I was looking for a way to extend napalm in a somewhat predictable matter. Here is what I came up with. You would need to have a custom_napalm_* library and Custom* class to import anywhere you wanted to use the additional features. 

respective driver update:

```
(napalm-dir) ken@kcelenza-ubuntu:/github/sample/1/napalm-ios$ git diff
diff --git a/napalm_ios/__init__.py b/napalm_ios/__init__.py
index a322d7f..2aba9d5 100644
--- a/napalm_ios/__init__.py
+++ b/napalm_ios/__init__.py
@@ -14,7 +14,10 @@

 """napalm_ios package."""
 import pkg_resources
-from napalm_ios.ios import IOSDriver
+try:
+    from custom_napalm.ios import CustomIOSDriver as IOSDriver
+except:
+    from napalm_ios.ios import IOSDriver

 try:
     __version__ = pkg_resources.get_distribution('napalm-ios').version
diff --git a/napalm_ios/ios.py b/napalm_ios/ios.py
index 2447e73..c027f70 100644
--- a/napalm_ios/ios.py
+++ b/napalm_ios/ios.py
@@ -25,7 +25,10 @@ import telnetlib
 import copy

 from netmiko import ConnectHandler, FileTransfer, InLineTransfer
-from napalm_base.base import NetworkDriver
+try:
+    from custom_napalm.base import CustomNetworkDriver as NetworkDriver
+except ImportError:
+    from napalm_base.base import NetworkDriver
 from napalm_base.exceptions import ReplaceConfigException, MergeConfigException, \
             ConnectionClosedException, CommandErrorException

(napalm-dir) ken@kcelenza-ubuntu:/github/sample/1/napalm-ios$
```

example extension
```
(napalm-dir) ken@kcelenza-ubuntu:~/.virtualenvs/napalm-dir/local/lib/python2.7/site-packages/custom_napalm$ ls
base.py  __init__.py  ios.py
(napalm-dir) ken@kcelenza-ubuntu:~/.virtualenvs/napalm-dir/local/lib/python2.7/site-packages/custom_napalm$ cat base.py
from napalm_base.base import NetworkDriver
class CustomNetworkDriver(NetworkDriver):

    def get_eigrp(self):
        raise NotImplementedError

    def get_trustsec(self):
        raise NotImplementedError

(napalm-dir) ken@kcelenza-ubuntu:~/.virtualenvs/napalm-dir/local/lib/python2.7/site-packages/custom_napalm$ cat ios.py

from napalm_ios.ios import IOSDriver
class CustomIOSDriver(IOSDriver):
    """NAPALM Cisco IOS Handler."""

    def get_eigrp(self):
        ntp_servers = {}
        command = 'show run | include ntp server'
        output = self._send_command(command)

        for line in output.splitlines():
            split_line = line.split()
            if "vrf" == split_line[2]:
                ntp_servers[split_line[4]] = {}
            else:
                ntp_servers[split_line[2]] = {}

        return ntp_servers

(napalm-dir) ken@kcelenza-ubuntu:~/.virtualenvs/napalm-dir/local/lib/python2.7/site-packages/custom_napalm$
```