### PR TITLE
Remove download counter which no longer works

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![PyPI](https://img.shields.io/pypi/v/napalm-base.svg)](https://pypi.python.org/pypi/napalm-base)
-[![PyPI](https://img.shields.io/pypi/dm/napalm-base.svg)](https://pypi.python.org/pypi/napalm-base)
 [![Build Status](https://travis-ci.org/napalm-automation/napalm-base.svg?branch=master)](https://travis-ci.org/napalm-automation/napalm-base)
 
 


### PR DESCRIPTION
Removing the download counter which has stopped working:
[![PyPI](https://img.shields.io/pypi/dm/napalm-base.svg)](https://pypi.python.org/pypi/napalm-base)

It can give the wrong impression of the project. And of course, so that everything looks nice for the hacktoberfest. :)